### PR TITLE
Use real charts repo for wbstack charts

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -103,7 +103,6 @@ releases:
 - name: api
   chart: wbstack/api
   version: 0.3.0
-  version: 0.2.0
   namespace: default
   values:
   - "env/{{ .Environment.Name }}/api.values.yaml.gotmpl"


### PR DESCRIPTION
Split from the wbstack deploy repo
Published with github pages
https://github.com/wbstack/charts

It should also appear on https://artifacthub.io/ soon