### PR TITLE
helm local: Turn off queryservice health checks

### DIFF
--- a/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
@@ -2,6 +2,7 @@ image:
   repository: ghcr.io/wbstack/queryservice
   tag: "0.3.6_0.6"
   pullPolicy: Always
+useProbes: false
 app:
   heapSize: 1g
 resources:

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -130,7 +130,7 @@ releases:
 - name: queryservice
   namespace: default
   chart: wbstack/queryservice
-  version: 0.1.0
+  version: 0.1.1
   values:
   - "env/{{ .Environment.Name }}/queryservice.values.yaml.gotmpl"
 - name: queryservice-gateway


### PR DESCRIPTION
These seem to constantly fail currently with:

Readiness probe failed: Get "http://172.17.0.17:9999/bigdata/"
context deadline exceeded (Client.Timeout exceeded while awaiting headers)

Not sure why, but let's just disable them for now!

This changes the helm chart version that is used in production too, so an `apply` should be done there once merged.