### PR TITLE
local: Add REPLICA MONITOR to mediawiki-db-manager for updated sql

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -13,13 +13,13 @@ useProbes: false
 {{- end }}
 
 image:
-  repository: ghcr.io/toban/api
+  repository: ghcr.io/wbstack/api
   tag:
-    backend: 8x.1.7-shortcut-v2
-    preinstall: 8x.1.7-shortcut-v2
-    web: 8x.1.7-shortcut-v2
-    queue: 8x.1.7-shortcut-v2
-    scheduler: 8x.1.7-shortcut-v2
+    backend: main
+    preinstall: main
+    web: main
+    queue: main
+    scheduler: main
 
 platform:
   backendMwHost: mediawiki-135-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/local/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/sql.values.yaml.gotmpl
@@ -153,9 +153,7 @@ initdbScripts:
     # Needed in order to create new users
     echo "GRANT CREATE USER ON *.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
     # In order to see and grant slave status access
-    echo "GRANT REPLICATION CLIENT ON *.* TO 'mediawiki-db-manager'@'%' WITH GRANT OPTION;" >> /tmp/sql-init-cmds-001.txt
     echo "GRANT REPLICA MONITOR ON *.* TO 'mediawiki-db-manager'@'%' WITH GRANT OPTION;" >> /tmp/sql-init-cmds-001.txt
-
 
     # Flush privs
     echo "FLUSH PRIVILEGES;" >> /tmp/sql-init-cmds-001.txt


### PR DESCRIPTION
also bumps the versions to use the new api tweak until merged into main