### PR TITLE
Add missing wbstack chart repo (mailgun followup)

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -7,6 +7,8 @@ repositories:
   url: https://charts.jetstack.io
 - name: wbstack-deploy-charts
   url: git+https://github.com/wbstack/deploy/@charts?ref=main
+- name: wbstack
+  url: https://wbstack.github.io/charts
 - name: bitnami
   url: https://charts.bitnami.com/bitnami
 - name: cetic


### PR DESCRIPTION
This was missed in
c8c531fce039329c36adfe16659c68c292fac601

Which added usage of a repository that was
not specified in the helmfile
