### PR TITLE
helmfile: Make default context invalid

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -16,6 +16,8 @@ repositories:
   url: https://helm.mittwald.de
 
 environments:
+  default:
+    kubeContext: INVALID-ENVIRONMENT
   production:
     kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-1
     values:


### PR DESCRIPTION
This will avoid ever accidently applying these helm
deployments to the wrong place by forgetting to
specify an environment
