### PR TITLE
prod: add missing dot to subdomain suffix

### DIFF
--- a/k8s/helmfile/env/production/base.yaml
+++ b/k8s/helmfile/env/production/base.yaml
@@ -3,4 +3,4 @@ ingressHost: "*.wikibase.dev"
 tls: true
 forceSSL: true
 wbstack:
-  subdomainSuffix: 'wikibase.dev'
+  subdomainSuffix: '.wikibase.dev'


### PR DESCRIPTION
This config value is shared by the API and the UI. Both expect the value to start with a dot:
https://github.com/wbstack/ui/blob/2a59c23b383dfb096e1f5c34b144690d4d16cea3/src/components/Cards/CreateWiki.vue#L188
https://github.com/wbstack/api/blob/e79c9b8e7119e6b3f8951776390dfd26abec9261/config/wbstack.php#L5