### PR TITLE
Add wbstack-pr comment

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -7,9 +7,9 @@ repositories:
   url: https://wbstack.github.io/charts
 - name: bitnami
   url: https://charts.bitnami.com/bitnami
+# Not used for live deployments
 - name: cetic
   url: https://cetic.github.io/helm-charts
-# Not used for live deployments
 - name: mittwald
   url: https://helm.mittwald.de
 - name: elastic


### PR DESCRIPTION
Lets add a comment that you can easily use to use a PR branch of the charts repo.

This also removes unused mogaal-adminer and moves the other adminer under the "not live" comment