### PR TITLE
Makefile: make local and staging commands easier

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,27 @@ minikube-dashboard:
 
 minikube-tunnel:
 	./bin/minikube-tunnel
+
+.PHONY: helmfile-deps
+
+# Fetch all deps defined in the helmfile.
+# local environment is used (as one is needed), and any will do
+helmfile-deps:
+	cd ./k8s/helmfile && helmfile --environment local fetch
+
+.PHONY: local local-diff
+local-diff:
+	cd ./tf/env/local && terraform plan
+	cd ./k8s/helmfile && helmfile --environment local diff --context 10 --skip-deps
+local:
+	cd ./tf/env/local && terraform apply
+	cd ./k8s/helmfile && helmfile --environment local diff --interactive --context 10 --skip-deps
+
+# Note: the staging command here actually terraform applies all of production
+.PHONY: staging staging-diff
+staging-diff:
+	cd ./tf/env/prod && terraform plan
+	cd ./k8s/helmfile && helmfile --environment staging diff --context 10 --skip-deps
+staging:
+	cd ./tf/env/prod && terraform apply
+	cd ./k8s/helmfile && helmfile --environment staging diff --interactive --context 10 --skip-deps


### PR DESCRIPTION
This introduced a few new commands aimed at making
syncing things in the 2 existing deployments easier.
This includes terraform and also helmfile.

This potentially highlights something that we may want
to change, which is that terraform is for the whole of our
google environment right now, vs helm which is per environment.
