### PR TITLE
Update Makefile to differentiate between diff-ing and apply-ing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,19 +22,19 @@ minikube-tunnel:
 helmfile-deps:
 	cd ./k8s/helmfile && helmfile --environment local fetch
 
-.PHONY: local local-diff
-local-diff:
+.PHONY: diff-local apply-local
+diff-local:
 	cd ./tf/env/local && terraform plan
 	cd ./k8s/helmfile && helmfile --environment local diff --context 10 --skip-deps
-local:
+apply-local:
 	cd ./tf/env/local && terraform apply
 	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 10 --skip-deps
 
 # Note: the staging command here actually terraform applies all of production
-.PHONY: staging staging-diff
-staging-diff:
+.PHONY: diff-staging apply-staging
+diff-staging:
 	cd ./tf/env/prod && terraform plan
 	cd ./k8s/helmfile && helmfile --environment staging diff --context 10 --skip-deps
-staging:
+apply-staging:
 	cd ./tf/env/prod && terraform apply
 	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 10 --skip-deps


### PR DESCRIPTION
Changed so that one doesn't accidentally run `make staging` instead of `make staging-diff` ([as discussed in mattermost](https://mattermost.wikimedia.de/swe/pl/xqcju3q7dprj9c7onrt4438x8a)).
Changing this now before we all get too used to the current commands.
Open to other suggestions on what to name the commands.