### PR TITLE
Reduce the size of the hemfile context used in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,19 +25,19 @@ helmfile-deps:
 .PHONY: diff-local apply-local
 diff-local:
 	cd ./tf/env/local && terraform plan
-	cd ./k8s/helmfile && helmfile --environment local diff --context 10 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment local diff --context 5 --skip-deps
 apply-local:
 	cd ./tf/env/local && terraform apply
-	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 10 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 5 --skip-deps
 
 # Note: the staging command here actually terraform applies all of production
 .PHONY: diff-staging apply-staging
 diff-staging:
 	cd ./tf/env/prod && terraform plan
-	cd ./k8s/helmfile && helmfile --environment staging diff --context 10 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment staging diff --context 5 --skip-deps
 apply-staging:
 	cd ./tf/env/prod && terraform apply
-	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 10 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 5 --skip-deps
 
 .PHONY: skaffold-run
 skaffold-run:


### PR DESCRIPTION
How do people feel about me reducing the size of the helmfile context?

I prefer a smaller helmfile context of 5 like what is suggested [in the docs](https://github.com/wmde/wbaas-deploy/blob/main/doc/Local-dev-env.md#helmfile) as it allows me to more easily see all the changes. Any changes I don't understand due to lack of context can be investigated further outside of Makefile helper commands.