### PR TITLE
Pass individual values instead of whole yaml block

### DIFF
--- a/k8s/helmfile/env/local/base.yaml
+++ b/k8s/helmfile/env/local/base.yaml
@@ -1,5 +1,8 @@
 ip: ""
 ingressHost: "*.wbaas.localhost"
+ingressNameSuffix: main
+forceSSL: false
+tls: false
 wbstack:
   subdomainSuffix: ".wbaas.localhost"
   uiurl: http://wbaas.localhost

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -111,8 +111,10 @@ releases:
     namespace: default
     chart: ./../../charts/wikibase-dev-ingress
     values:
-      # TODO use more specific values (what is actually needed?) OR adopt this pattern everywhere
-      - {{ toYaml .Values | nindent 8 }}
+      - ingressNameSuffix: {{ .Values.ingressNameSuffix | toYaml }}
+      - ingressHost: {{ .Values.ingressHost | toYaml }}
+      - forceSSL: {{ .Values.forceSSL | toYaml }}
+      - tls: {{ .Values.tls | toYaml }}
 
   - name: api
     chart: wbstack/api


### PR DESCRIPTION
Passing individual values saves us from having to change the indentation
level in the `nindent` call, which can lead to hard to debug problems.
It also makes it clearer which values the chart expects.

This tripped us up quite a bit in 121d534.