### PR TITLE
Don't use `--skip-deps` for production commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,10 @@ apply-local:
 .PHONY: diff-staging apply-staging
 diff-staging:
 	cd ./tf/env/prod && terraform plan
-	cd ./k8s/helmfile && helmfile --environment staging diff --context 5 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment staging diff --context 5
 apply-staging:
 	cd ./tf/env/prod && terraform apply
-	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 5 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 5
 
 .PHONY: skaffold-run
 skaffold-run:


### PR DESCRIPTION
This flag makes sense for speeding up commands running against the local
cluster, but it probably does more harm than good in production. We
spent a few minutes being confused about a "missing" chart version
during a deployment.