### PR TITLE
TF: Fix local lockfile

### DIFF
--- a/tf/env/local/.terraform.lock.hcl
+++ b/tf/env/local/.terraform.lock.hcl
@@ -1,24 +1,6 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/google" {
-  version = "3.87.0"
-  hashes = [
-    "h1:RLPrX2KV7pJ55mATEoKbshMyrR4OmYAYtTc9/O2vLro=",
-    "zh:08583ab738fdbd89daef6f5ca44ca20de8b5c3b8c02f9f441337e5d7ac9508dc",
-    "zh:1ab03b68d05acb72f765b7556a45c153ae12d5c1a24d1d0be28b9bad9c00bb41",
-    "zh:2f9ce9369f12fa2164ac18e0e6d9672d2bc3d4300f03fa3daf6027e952e63890",
-    "zh:4c7d4690dc0bd9eacbd64aa887a41ddc69c71574ac054e6016f81ec4573f794a",
-    "zh:627df6e7e1d8f84bb465c2375ca4104a73b755c47f38059327e417b024f9bd3b",
-    "zh:b3eb129ae1cc70e38ce45d5770008c444d9f046f832a03ba7c7b5a34313ef8d4",
-    "zh:b83898db9bd974e7a1f5a886a395667cdb7b5acfac7ba184f9b713a5d8a7e8c2",
-    "zh:cd624f4372ad413645a4ffe80c29152f3f74d727969e623ec8da300c452cd7e1",
-    "zh:dc4f6f3dcdd1814ea0dfc6ea41cee248359daff366d74735d65e5cb3202bae3c",
-    "zh:e80579ea568f36fb4aa5e37c293111d7782c2f4929c5d16297259acc78a9875b",
-    "zh:f83cecac66e0e3aed2c586f3d57164ca8edf306d874879873c0202d0ca883faf",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/helm" {
   version = "2.3.0"
   hashes = [
@@ -89,16 +71,5 @@ provider "registry.terraform.io/hashicorp/tls" {
     "zh:e9b672210b7fb410780e7b429975adcc76dd557738ecc7c890ea18942eb321a5",
     "zh:eb1f8368573d2370605d6dbf60f9aaa5b64e55741d96b5fb026dbfe91de67c0d",
     "zh:fc1e12b713837b85daf6c3bb703d7795eaf1c5177aebae1afcf811dd7009f4b0",
-  ]
-}
-
-provider "registry.terraform.io/kyma-incubator/kind" {
-  version     = "0.0.9"
-  constraints = "0.0.9"
-  hashes = [
-    "h1:YNzKZMWA0LaA06JQwJBiMDn5dQxLbfn8hbGriMyoejs=",
-    "zh:402d460a4351d9733ff31de24c39026fb7cb2242d1500f5cf348d17f0ec4643c",
-    "zh:9361aca5e41a0906746605d186424b5404681240f7ed17aeefc5e1afd628ee24",
-    "zh:e8467161989c61adee2d7d50a31535b07a17e27315b993c36d4fb1271a15a7a7",
   ]
 }


### PR DESCRIPTION
Currently the local lockfile appears to reference providers that
are not present in the providers file.

This means that `terraform plan` etc. fails to apply in the case
that you don't happen to have an old copy of these providers
hanging around in your .terraform cache