### PR TITLE
Bump MW chart to 0.7.5

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -141,7 +141,7 @@ releases:
   - name: mediawiki-137-fp
     namespace: default
     chart: wbstack/mediawiki
-    version: 0.7.4
+    version: 0.7.5
     values:
       - "env/{{ .Environment.Name }}/mediawiki-137-fp.values.yaml.gotmpl"
 


### PR DESCRIPTION
Bug: [T298759](https://phabricator.wikimedia.org/T298759)

Needs https://github.com/wbstack/charts/pull/44 merged first