### PR TITLE
Update mediawiki resources for local instance to make it not crash

### DIFF
--- a/k8s/helmfile/env/local/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-137-fp.values.yaml.gotmpl
@@ -43,18 +43,18 @@ mw:
 resources:
   web:
     requests:
-      cpu: 150m
-      memory: 350Mi
+      cpu: 0.5
+      memory: 500Mi
     limits:
-      cpu: 400m
-      memory: 750Mi
+      cpu: 1
+      memory: 1000Mi
   webapi:
     requests:
-      cpu: 200m
-      memory: 250Mi
+      cpu: 0.5
+      memory: 500Mi
     limits:
-      cpu: 500m
-      memory: 600Mi
+      cpu: 1
+      memory: 1000Mi
   alpha:
     requests:
       cpu: 50m
@@ -64,8 +64,8 @@ resources:
       memory: 600Mi
   backend:
     requests:
-      cpu: 10m
+      cpu: 0.5
       memory: 68Mi
     limits:
-      cpu: 50m
+      cpu: 1
       memory: 250Mi


### PR DESCRIPTION
Can't insert more than 5 items before it crashes without bumping this. No thought other than just bumping this at random.