### PR TITLE
Add make commands for whole repo diff and apply

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,6 @@ minikube-tunnel:
 helmfile-deps:
 	cd ./k8s/helmfile && helmfile --environment local fetch
 
-
-
 .PHONY: diff-local apply-local
 diff-local:
 	cd ./tf/env/local && terraform plan


### PR DESCRIPTION
If we start using these, we will not miss changes that we
were not expecting to make (while using diff), and we will
not forget to apply changes that we have merged (apply).

I'd be up for removing the more granular make commands for
staging and production too.
If we ever want to do the "non default" and only apply something
in once place, then we should be forced to cd around and have more
awareness that we are only doing things in certain places.

But this seems like a good start
