### PR TITLE
Up to mw-backend resource for migration reasons again

### DIFF
--- a/k8s/helmfile/env/staging/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-137-fp.values.yaml.gotmpl
@@ -61,7 +61,7 @@ resources:
   backend:
     requests:
       cpu: 500m
-      memory: 350Mi
+      memory: 600Mi
     limits:
       cpu: 1000m
-      memory: 600Mi
+      memory: 1200Mi


### PR DESCRIPTION
the dumpRdf script is apparently quite memory hungry? possibly has some memory leak?
So up the memory limit to avoid blocking migration.

FOr a 500k wiki (largest) at 383k entities dumped we hit the existing 600MB limit.
1.2G should be plenty