### PR TITLE
[T301140.2] Add real cname record to staging

### DIFF
--- a/tf/env/staging/dns.tf
+++ b/tf/env/staging/dns.tf
@@ -80,7 +80,7 @@ resource "google_dns_record_set" "dev-MailGun-record" {
 
 resource "google_dns_record_set" "dev-dyna-A" {
     managed_zone = google_dns_managed_zone.dev.name
-    name         = local.dynamic_dns_host
+    name         = module.wbaas-config.cname_record
     rrdatas      = [
         google_compute_address.default.address,
     ]

--- a/tf/env/staging/variables.tf
+++ b/tf/env/staging/variables.tf
@@ -15,7 +15,6 @@ variable "terraformers" {
 
 locals {
   staging_cluster_name = "wbaas-2"
-  dynamic_dns_host = "sites-1.dyna.wikibase.dev."
 }
 
 variable "mailgun_api_key" {


### PR DESCRIPTION
Inspired by the existing config in wbstack

https://github.com/wbstack/deploy/blob/main/gce/dns/zone-wbstack#L71
https://github.com/wbstack/deploy/blob/main/gce/dns/zone-wbstack#L33

poking @addshore to have a look if this is all that would be required?