### PR TITLE
Use Skaffold Modules

### DIFF
--- a/skaffold/README.md
+++ b/skaffold/README.md
@@ -27,9 +27,6 @@ wbstack/
 
 https://skaffold.dev/docs/install/
 
-This is very much a work in progress & might not work at all and certainly not be fully optimized etc...
-
-
 ## Use with minikube deployed helm charts
 
 Inside the `skaffold/` directory run
@@ -52,6 +49,11 @@ Currently the following services are hooked up to skaffold:
 - [tool-cradle](https://github.com/wbstack/cradle)
 - [tool-widar](https://github.com/wbstack/widar)
 - [tool-quickstatements](https://github.com/wbstack/quickstatements)
+
+These are all configured as seperate modules. To run a single module run
+```sh
+shaffold run -m <module>
+```
 
 
 ## Reading

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -8,24 +8,6 @@ profiles:
       artifacts:
         - image: local/skaffold/wbaas/ui
           context: ./../../ui
-        - image: local/skaffold/wbaas/mediawiki
-          context: ./../../mediawiki
-        - image: local/skaffold/wbaas/api
-          context: ./../../api
-        - image: local/skaffold/wbaas/queryservice-gateway
-          context: ./../../queryservice-gateway
-        - image: local/skaffold/wbaas/queryservice-ui
-          context: ./../../queryservice-ui
-        - image: local/skaffold/wbaas/queryservice
-          context: ./../../queryservice
-        - image: local/skaffold/wbaas/queryservice-updater
-          context: ./../../queryservice-updater
-        - image: local/skaffold/wbaas/tool-cradle
-          context: ./../../cradle
-        - image: local/skaffold/wbaas/tool-widar
-          context: ./../../widar
-        - image: local/skaffold/wbaas/tool-quickstatements
-          context: ./../../quickstatements
       local:
         useDockerCLI: true
     deploy:
@@ -41,6 +23,31 @@ profiles:
               image: local/skaffold/wbaas/ui
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "ui", "-n" ]
+metadata:
+  name: ui
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/mediawiki
+          context: ./../../mediawiki
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: mediawiki-137-fp
             chartPath: ./../../charts/charts/mediawiki
             valuesFiles:
@@ -50,6 +57,31 @@ profiles:
               image: local/skaffold/wbaas/mediawiki
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "mediawiki-137-fp", "-n" ]
+metadata:
+  name: mediawiki-137-fp
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/api
+          context: ./../../api
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: api
             chartPath: ./../../charts/charts/api
             valuesFiles:
@@ -59,6 +91,31 @@ profiles:
               image: local/skaffold/wbaas/api
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "api", "-n" ]
+metadata:
+  name: api
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/queryservice-gateway
+          context: ./../../queryservice-gateway
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: queryservice-gateway
             chartPath: ./../../charts/charts/queryservice-gateway
             valuesFiles:
@@ -68,6 +125,31 @@ profiles:
               image: local/skaffold/wbaas/queryservice-gateway
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice-gateway", "-n" ]
+metadata:
+  name: queryservice-gateway
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/queryservice-ui
+          context: ./../../queryservice-ui
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: queryservice-ui
             chartPath: ./../../charts/charts/queryservice-ui
             valuesFiles:
@@ -77,6 +159,31 @@ profiles:
               image: local/skaffold/wbaas/queryservice-ui
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice-ui", "-n" ]
+metadata:
+  name: queryservice-ui
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/queryservice
+          context: ./../../queryservice
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: queryservice
             chartPath: ./../../charts/charts/queryservice
             valuesFiles:
@@ -86,6 +193,31 @@ profiles:
               image: local/skaffold/wbaas/queryservice
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice", "-n" ]
+metadata:
+  name: queryservice
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/queryservice-updater
+          context: ./../../queryservice-updater
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: queryservice-updater
             chartPath: ./../../charts/charts/queryservice-updater
             valuesFiles:
@@ -95,6 +227,31 @@ profiles:
               image: local/skaffold/wbaas/queryservice-updater
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice-updater", "-n" ]
+metadata:
+  name: queryservice-updater
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/tool-cradle
+          context: ./../../cradle
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: tool-cradle
             chartPath: ./../../charts/charts/tool-cradle
             valuesFiles:
@@ -104,6 +261,31 @@ profiles:
               image: local/skaffold/wbaas/tool-cradle
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "tool-cradle", "-n" ]
+metadata:
+  name: tool-cradle
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/tool-widar
+          context: ./../../widar
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: tool-widar
             chartPath: ./../../charts/charts/tool-widar
             valuesFiles:
@@ -113,6 +295,31 @@ profiles:
               image: local/skaffold/wbaas/tool-widar
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "tool-widar", "-n" ]
+metadata:
+  name: tool-widar
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/tool-quickstatements
+          context: ./../../quickstatements
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: tool-quickstatements
             chartPath: ./../../charts/charts/tool-quickstatements
             valuesFiles:
@@ -125,22 +332,6 @@ profiles:
         hooks:
           before:
             - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "ui", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "mediawiki-137-fp", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "api", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice-gateway", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice-ui", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "queryservice-updater", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "tool-cradle", "-n" ]
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "tool-widar", "-n" ]
-            - host:
                 command: [ "./helmfile-values", "-e", "local", "-r", "tool-quickstatements", "-n" ]
+metadata:
+  name: tool-quickstatements


### PR DESCRIPTION
This commit converts the single large skaffold config into many (10)
independent skaffold modules[1].

To run a single module rather than all 10 one can use:
`skaffold run -m <module e.g ui>`

[1] https://skaffold.dev/docs/design/config/#multiple-configuration-support