### PR TITLE
Add snapshot schedule for mariadb-secondary pvc

### DIFF
--- a/tf/env/staging/disk.tf
+++ b/tf/env/staging/disk.tf
@@ -12,8 +12,8 @@ resource "google_compute_disk" "data-sql-mariadb-secondary" {
 }
 
 resource "kubernetes_persistent_volume" "data-sql-mariadb-secondary" {
-
-    provider = kubernetes.wbaas-2
+  provider = kubernetes.wbaas-2
+  
   metadata {
     name = "pv-data-sql-mariadb-secondary-0"
   }


### PR DESCRIPTION
~This PR adds the terraform module `disks`, which introduces scheduled snapshots of the mariadb replica PVC.~

This PR defines the disk and PV for the mariadb replica, and introduces a scheduled snapshots of it.

- [x] snapshots of the data in the running mysql replica (secondary) pod
- [x] defined in terraform
- [x] copy daily and retain them for 7 days
- [x] kept outside of the geographical region the cluster (europe-north1)

https://phabricator.wikimedia.org/T298799