### PR TITLE
tf: Adjust data flow for smtp password

### DIFF
--- a/tf/env/production/kubernetes-secrets.tf
+++ b/tf/env/production/kubernetes-secrets.tf
@@ -5,7 +5,7 @@ module "wbaas-k8s-secrets" {
   }
   domain_mailgun_key = var.domain_mailgun_key
   smtp_username = mailgun_domain.default.smtp_login
-  smtp_password = mailgun_domain.default.smtp_password
+  smtp_password = random_password.smtp-password.result
   google_service_account_key_api = google_service_account_key.api.private_key
   google_service_account_key_dns = google_service_account_key.certman-dns-cloud-solver.private_key
   sql_password_root = random_password.sql-passwords["production-root"].result

--- a/tf/env/staging/kubernetes-secrets.tf
+++ b/tf/env/staging/kubernetes-secrets.tf
@@ -5,7 +5,7 @@ module "wbaas2-k8s-secrets" {
   }
   domain_mailgun_key = var.domain_mailgun_key
   smtp_username = mailgun_domain.default.smtp_login
-  smtp_password = mailgun_domain.default.smtp_password
+  smtp_password = random_password.smtp-password.result
   google_service_account_key_api = google_service_account_key.dev-api.private_key
   google_service_account_key_dns = google_service_account_key.certman-dns01-solver.private_key
   sql_password_root = random_password.sql-passwords["staging-root"].result


### PR DESCRIPTION
Due to the constraints of the mailgun resource we ignore
changes on the smtp_password. However, under the hood this
this is stored as a blank value in the terraform state.

This used propagates to the k8s secret if the k8s secret has to be
recreated for some reason which results in email failures.

This patch adjusts the flow of data so we directly use the
random_secret resource to create the k8s secret.