### PR TITLE
Document templates in backup _helpers.tpl file

### DIFF
--- a/charts/wbaas-backup/templates/_helpers.tpl
+++ b/charts/wbaas-backup/templates/_helpers.tpl
@@ -1,12 +1,18 @@
 {{/* vim: set filetype=mustache: */}}
-{{ define "backup.sharedVolumes" }}
-{{- if .gcs.uploadToBucket }}
-volumes:
-  - name: "service-account-volume"
-    secret:
-      secretName: {{ .gcs.serviceAccountSecretName | quote }}
-{{- end }}
-{{ end }}
+
+{{- /*
+## `backup.sharedPodConfiguration`
+
+The restore pod and the CronJob share the same configuration.
+
+Depending on the situation, if the CronJob is running or Restore-pod is running the `db` dict for this template
+either will be set to use the `db.load` dict or the `db.dump` dict from the values configuration.
+
+`db.load` is used when restoring and is by default configured to restore the primary sql instance
+`db.dump` is used when backing up (through the CronJob) and is by default configured to take backups from the replica
+
+*/}}
+
 {{- define "backup.sharedPodConfiguration" -}}
 {{- if .context.Values.gcs.uploadToBucket }}
 volumeMounts:
@@ -46,3 +52,19 @@ env:
       name: backup-openssl-key
       key: {{ .context.Values.backupSecretKey }}
 {{- end -}}
+
+
+{{- /*
+## `backup.sharedVolumes`
+
+Both the restore-pod and the CronJob requires the backup-bucket to be mounted in order for the backups to be persisted.
+This template mounts the `.Values.gcs` of the values file into the template and configures the pod and the job in the same way.
+*/}}
+{{ define "backup.sharedVolumes" }}
+{{- if .gcs.uploadToBucket }}
+volumes:
+  - name: "service-account-volume"
+    secret:
+      secretName: {{ .gcs.serviceAccountSecretName | quote }}
+{{- end }}
+{{ end }}


### PR DESCRIPTION
This re-organizes the _helpers.tpl file in the way the templates are
used in the chart. It also tries to adds some comments explaining what
each template is doing and what it's used for.