### PR TITLE
tf: monitoring remove use of locals

### DIFF
--- a/tf/modules/monitoring/main.tf
+++ b/tf/modules/monitoring/main.tf
@@ -1,10 +1,6 @@
-locals {
-  sql-replication-error-metric-name = "${var.cluster_name}-mariadb-sql-errno-1236-error-count"
-}
-
 #https://www.percona.com/blog/2014/10/08/mysql-replication-got-fatal-error-1236-causes-and-cures/
 resource "google_logging_metric" "mariadb-server_errno-1236" {
- name   = "${local.sql-replication-error-metric-name}"
+ name   = "${var.cluster_name}-mariadb-sql-errno-1236-error-count"
  filter = "resource.labels.cluster_name=\"${var.cluster_name}\" AND resource.labels.container_name=\"mariadb\" AND textPayload:\"server_errno=1236\""
  metric_descriptor {
    metric_kind = "DELTA"
@@ -22,7 +18,7 @@ resource "google_monitoring_alert_policy" "alert_policy_replica_failure" {
     display_name = "(${var.cluster_name}): SQL replica errorno 1236"
     condition_threshold {
     # resource.type needed because of https://github.com/hashicorp/terraform-provider-google/issues/4165
-    filter          = "metric.type=\"logging.googleapis.com/user/${local.sql-replication-error-metric-name}\" AND resource.type=\"k8s_container\""
+    filter          = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.mariadb-server_errno-1236.name}\" AND resource.type=\"k8s_container\""
     duration        = "60s"
     comparison      = "COMPARISON_GT"
     aggregations {


### PR DESCRIPTION
This removes the use of locals in this module.
Generally they are best used very sparingly[1].

Also in this case using them removed a dependency that
can prevent the provider from cleanly applying the state.
This was the case when I applied the preceeding state;
it required a double application.

Since the alert policy can only be using a metric that
already exists the provider needs to know the order that the
resources need to be created. This is normally hinted to TF
by using attributes of those resources[2].

[1] https://www.terraform.io/language/values/locals#when-to-use-local-values
[2] https://learn.hashicorp.com/tutorials/terraform/dependencies