### PR TITLE
local: Add seconds behind master readiness check for secondary 

### DIFF
--- a/k8s/helmfile/env/local/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/sql.values.yaml.gotmpl
@@ -72,7 +72,7 @@ secondary:
   readinessProbe:
     enabled: false
   customReadinessProbe:
-        initialDelaySeconds: 10
+        initialDelaySeconds: 20
         periodSeconds: 10
         timeoutSeconds: 5
         successThreshold: 1
@@ -89,8 +89,17 @@ secondary:
               fi
               SECONDS_BEHIND=$(mysql -e "show slave status\G" -uroot -p$PASSWORD_AUX | grep "Seconds_Behind_Master" | awk '{print $2}')
               SECONDS_BEHIND=${SECONDS_BEHIND%.*}
-              echo "$SECONDS_BEHIND seconds behind primary"
-              if [[ ${SECONDS_BEHIND} =~ ^-?[0-9]+$ && $REPLICATION_THRESHOLD -gt ${SECONDS_BEHIND} ]]; then exit 0; else exit 1; fi
+              if [[ $SECONDS_BEHIND = "NULL" ]];
+              then
+                echo "Replication isn't running yet got NULL seconds behind primary!"
+                exit 1;
+              elif [[ ${SECONDS_BEHIND} =~ ^-?[0-9]+$ && $REPLICATION_THRESHOLD -gt ${SECONDS_BEHIND} ]];
+              then
+                exit 0;
+              else
+                echo "More than $REPLICATION_THRESHOLD seconds behind primary"
+                exit 1;
+              fi
   persistence:
     enabled: true
     size: {{ .Values.services.sql.storageSize | quote }}


### PR DESCRIPTION
- ~~Bump bitnami/mariadb to latest from main 10.5.0~~ done in https://github.com/wmde/wbaas-deploy/tree/bump-maria-db
- use the customReadinessProbe
- ~~introduces a `shared-values.yaml` file at the helmfile root to avoid repeating ourselves.~~  

for testing: https://mariadb.com/kb/en/delayed-replication/

```
Database changed
MariaDB [apidb]> STOP SLAVE;
Query OK, 0 rows affected (0.001 sec)

MariaDB [apidb]> CHANGE MASTER TO master_delay=3600;
Query OK, 0 rows affected (0.004 sec)

MariaDB [apidb]> START SLAVE;
Query OK, 0 rows affected (0.000 sec)

```

Any new changes will be delayed by 3600 seconds

https://artifacthub.io/packages/helm/bitnami/mariadb#to-10-0-0