### PR TITLE
Revert "staging: use tf-module-monitoring-1 (#224)"

### DIFF
--- a/tf/env/staging/monitoring.tf
+++ b/tf/env/staging/monitoring.tf
@@ -1,5 +1,5 @@
 module "staging-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-1"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-0"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }


### PR DESCRIPTION
This reverts commit faa38c82312d25becc56cfd2ecb98ac16bcb2b82.

tf modulle monitoring v1 is not applyable