### PR TITLE
Staging/local: bump bitnami/mariadb to 10.5.0

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -84,10 +84,8 @@ releases:
 
   - name: sql
     namespace: default
-    # TODO reevaluate upstreaming addshore/bitnami-charts(7.3.16-mariadb-ready-check-seconds)
-    # modifications
     chart: bitnami/mariadb
-    version: 9.6.2
+    version: '{{ if eq .Environment.Name "production" }} 9.6.2 {{ else }} 10.5.0 {{ end }}'
     values:
       - "env/{{ .Environment.Name }}/sql.values.yaml.gotmpl"
 


### PR DESCRIPTION
This is the latest from main of this chart and allows for
customReadinessProbes. We will probably do this update at some point and
would make more sense to do it before the migration starts.