### PR TITLE
Remove `--skip-deps` from local make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,10 @@ helmfile-deps:
 .PHONY: diff-local apply-local
 diff-local:
 	cd ./tf/env/local && terraform plan
-	cd ./k8s/helmfile && helmfile --environment local diff --context 5 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment local diff --context 5
 apply-local:
 	cd ./tf/env/local && terraform apply
-	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 5 --skip-deps
+	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 5
 
 init:
 	cd ./tf/env/${ENVIRONMENT} && terraform init


### PR DESCRIPTION
This removes the `--skip-deps` switch from the local Makefile targets, since it kind of breaks our workflow using the Makefile.

example: If you want to test a new chart locally you'd have to update your repos manually, which we don't have documented 