### PR TITLE
Makefile: Add `terraform init` to every make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,10 +25,10 @@ helmfile-deps:
 
 .PHONY: diff-local apply-local
 diff-local:
-	cd ./tf/env/local && terraform plan
+	cd ./tf/env/local && terraform init && terraform plan
 	cd ./k8s/helmfile && helmfile --environment local diff --context 5 --skip-deps
 apply-local:
-	cd ./tf/env/local && terraform apply
+	cd ./tf/env/local && terraform init && terraform apply
 	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 5 --skip-deps
 
 
@@ -38,20 +38,20 @@ apply: apply-staging apply-production
 
 .PHONY: diff-staging apply-staging
 diff-staging:
-	cd ./tf/env/staging && terraform plan
+	cd ./tf/env/staging && terraform init && terraform plan
 	cd ./k8s/helmfile && helmfile --environment staging diff --context 5
 # Note: the staging command here actually terraform applies all of staging
 apply-staging:
-	cd ./tf/env/staging && terraform apply
+	cd ./tf/env/staging && terraform init && terraform apply
 	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 5
 
 .PHONY: diff-production apply-production
 diff-production:
-	cd ./tf/env/production && terraform plan
+	cd ./tf/env/production && terraform init && terraform plan
 	cd ./k8s/helmfile && helmfile --environment production diff --context 5
 # Note: the production command here actually terraform applies all of production
 apply-production:
-	cd ./tf/env/production && terraform apply
+	cd ./tf/env/production && terraform init && terraform apply
 	cd ./k8s/helmfile && helmfile --environment production --interactive apply --context 5
 
 .PHONY: skaffold-run


### PR DESCRIPTION
This PR adds a `terraform init` call to every target in our Makefile to reduce manual steps while deploying

https://github.com/wmde/wbaas-deploy/pull/242#pullrequestreview-945439399