### PR TITLE
Release `tf-module-uptime-0`

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-uptime-0
+- Add modular uptime checks
+
 # tf-module-monitoring-3
 - Revert broken changes from tf-module-monitoring-1
 


### PR DESCRIPTION
This PR adds the uptime terraform module to the module changelog and should get tagged after merging