### PR TITLE
wbaas-backup: use 0.0.4 for all environments

### DIFF
--- a/k8s/helmfile/env/local/wbaas-backup.yaml.gotmpl
+++ b/k8s/helmfile/env/local/wbaas-backup.yaml.gotmpl
@@ -5,3 +5,8 @@ cronSchedule: "0 0 * * *"
 
 gcs:
   uploadToBucket: false
+
+resources:
+  job:
+    requests:
+      ephemeral-storage: 1Gi

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -188,7 +188,7 @@ releases:
   - name: wbaas-backup
     namespace: default
     chart: wbstack/wbaas-backup
-    version: 0.0.3
+    version: 0.0.4
     values:
       - "env/{{ .Environment.Name }}/wbaas-backup.yaml.gotmpl"
 


### PR DESCRIPTION
Set the local environment only to request 1GB storage

This depends on https://github.com/wbstack/charts/pull/84