### PR TITLE
k8s: Increase memory for elasticsearch

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
@@ -8,15 +8,15 @@ minimumMasterNodes: 1
 # For now we don't have enough nodes to have this set to hard
 antiAffinity: soft
 
-esJavaOpts: "-Xms1g -Xmx1g"
+esJavaOpts: "-Xms2g -Xmx2g"
 
 resources:
   requests:
     cpu: "500m"
-    memory: "1.5Gi"
+    memory: "4Gi"
   limits:
     cpu: "1250m"
-    memory: "2Gi"
+    memory: "4Gi"
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]

--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -8,15 +8,15 @@ minimumMasterNodes: 1
 # For now we don't have enough nodes to have this set to hard
 antiAffinity: soft
 
-esJavaOpts: "-Xms1g -Xmx1g"
+esJavaOpts: "-Xms2g -Xmx2g"
 
 resources:
   requests:
-    cpu: "750m"
-    memory: "1.5Gi"
+    cpu: "500m"
+    memory: "4Gi"
   limits:
     cpu: "1250m"
-    memory: "2Gi"
+    memory: "4Gi"
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]


### PR DESCRIPTION
It seems like the very slow / bad performance of ES node such that it is
unable to become ready may be due to memory exhaustion.

4GB of memory for the pod, half of which is allocated to the heap
seems like a reasonable place to start.

This also "Guaranteed QoS" for memory by setting pod request and
limit to be equal.

These numbers and the QoS strategy were derived from the examples in the
elastic cloud on k8s guide [1].

[1] https://www.elastic.co/guide/en/cloud-on-k8s/current/k8s-managing-compute-resources.html