### PR TITLE
k8s: temporarily suspend ES in production

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -93,6 +93,7 @@ releases:
     namespace: default
     chart: elastic/elasticsearch
     version: 6.8.18
+    installed: {{ ne .Environment.Name "production" | toYaml }}
     values:
       - "env/{{ .Environment.Name }}/elasticsearch.values.yaml.gotmpl"
 


### PR DESCRIPTION
In order to try and recover the disk let us uninstall
the elasticsearch chart from production.

We can revert this patch afterwards