### PR TITLE
Revert "k8s: temporarily suspend ES in production"

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -93,7 +93,6 @@ releases:
     namespace: default
     chart: elastic/elasticsearch
     version: 6.8.18
-    installed: {{ ne .Environment.Name "production" | toYaml }}
     values:
       - "env/{{ .Environment.Name }}/elasticsearch.values.yaml.gotmpl"
 


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#273

On again after killing the node