### PR TITLE
Deploy UI chart v0.2.16

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -130,7 +130,7 @@ releases:
   - name: ui
     namespace: default
     chart: wbstack/ui
-    version: 0.2.15
+    version: 0.2.16
     values:
       - "env/{{ .Environment.Name }}/ui.values.yaml.gotmpl"
 


### PR DESCRIPTION
This PR deploys the UI chart v0.2.16 which removes the federated properties CTA element

depends on https://github.com/wbstack/charts/pull/88