### PR TITLE
Staging: override chart resource node for wbaas-backup

### DIFF
--- a/k8s/helmfile/env/staging/wbaas-backup.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/wbaas-backup.yaml.gotmpl
@@ -5,3 +5,8 @@ gcs:
   bucketName: wikibase-dev-sql-backup
   serviceAccountSecretName: api-serviceaccount
   uploadToBucket: true
+
+resources:
+  job:
+    requests:
+      ephemeral-storage: 1Gi # TODO REMOVE here just to get it working to debug alerts


### PR DESCRIPTION
this will drop the ephemeral storage of 60Gb that stops it from starting.