### PR TITLE
This adds three build flags for the mediawiki skaffold config.

### DIFF
--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -42,6 +42,11 @@ profiles:
       artifacts:
         - image: local/skaffold/wbaas/mediawiki
           context: ./../../mediawiki
+          docker:
+            buildArgs:
+              LOCALIZATION_CACHE_THREAD_COUNT: 4
+              LOCALIZATION_CACHE_ADDITIONAL_PARAMS: "--lang=en,sv,de"
+              INSTALL_PROFILING_DEPS: 1
       local:
         useDockerCLI: true
     deploy:


### PR DESCRIPTION
LOCALIZATION_CACHE_THREAD_COUNT
tells the cache rebuild to use more threads

LOCALIZATION_CACHE_LANGUAGES
Tells the cache rebuild what languages to produce

INSTALL_PROFILING_DEPS
Install profiling dependencies in the docker image