### PR TITLE
Deploy UI chart 0.2.17 to staging and production

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -130,7 +130,7 @@ releases:
   - name: ui
     namespace: default
     chart: wbstack/ui
-    version: 0.2.16
+    version: 0.2.17
     values:
       - "env/{{ .Environment.Name }}/ui.values.yaml.gotmpl"
 


### PR DESCRIPTION
The new UI chart uses a new ui image, which only contains a string change

needs https://github.com/wbstack/charts/pull/89

https://phabricator.wikimedia.org/T306868