### PR TITLE
redis: Use SDD, allocate more resources

### DIFF
--- a/k8s/helmfile/env/staging/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/redis.values.yaml.gotmpl
@@ -12,24 +12,25 @@ commonConfiguration: |
   # Disable RDB persistence, AOF persistence already enabled.
   save ""
   # Control memory usage
-  maxmemory 50mb
+  maxmemory 75mb
   maxmemory-policy volatile-lru
   # Auto AOF file rewriting
   auto-aof-rewrite-percentage 100
-  auto-aof-rewrite-min-size 60mb
+  auto-aof-rewrite-min-size 85mb
 master:
   resources:
     requests:
-      cpu: 10m
-      memory: 62Mi
-    # Internal limit is 90MB, this for now just stops runaway redis..
+      cpu: 100m
+      memory: 125Mi
+    # Internal limit is 75MB, this for now just stops runaway redis..
     limits:
-      cpu: 50m
-      memory: 90Mi
+      cpu: 200m
+      memory: 150Mi
   persistence:
     enabled: true
     path: /data
     subPath: ""
+    storageClass: premium-rwo
     accessModes:
       - ReadWriteOnce
     size: 1Gi
@@ -37,17 +38,16 @@ replica:
   replicaCount: 1
   resources:
     requests:
-      cpu: 10m
-      # 60Mi based on usage seen on 21 December 2019 (after memory limits in place)
-      memory: 60Mi
-    # Internal limit is 90MB, this for now just stops runaway redis..
+      cpu: 40m
+      memory: 125Mi
     limits:
-      cpu: 50m
-      memory: 90Mi
+      cpu: 80m
+      memory: 150Mi
   persistence:
     enabled: true
     path: /data
     subPath: ""
+    storageClass: premium-rwo
     accessModes:
       - ReadWriteOnce
     size: 1Gi


### PR DESCRIPTION
- Changes resource allocations
- Changes how redis controls its own memory
- Switches from HDD to SSD, so that disk writes happen faster