### PR TITLE
Production: add new node + add more elasticsearch nodes

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
@@ -2,8 +2,8 @@ image: "wikibase/elasticsearch"
 imageTag: "6.8.23-wmde.6"
 imagePullPolicy: Always
 
-replicas: 1
-minimumMasterNodes: 1
+replicas: 3
+minimumMasterNodes: 2
 
 # For now we don't have enough nodes to have this set to hard
 antiAffinity: soft

--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -44,7 +44,7 @@ resource "google_container_node_pool" "wbaas-3_medium" {
 resource "google_container_node_pool" "wbaas-3_standard" {
     cluster = "wbaas-3"
     name                = "standard-pool"
-    node_count          = 3
+    node_count          = 4
     node_locations      = [
         "europe-west3-a",
     ]


### PR DESCRIPTION
This adds one more `e2-standard-2` node to the pool.

It also increases the elasticsearch master node count and replicas.