### PR TITLE
k8s: remove newline from nginx-ingress logs

### DIFF
--- a/k8s/helmfile/env/local/nginx-ingress.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/nginx-ingress.values.yaml.gotmpl
@@ -12,8 +12,8 @@ controller:
   config:
     block-user-agents: ~*Seekport\sCrawler.*
     # https://stackoverflow.com/a/37877244
-    log-format-upstream: >
+    log-format-upstream: >-
       $remote_addr - $remote_user [$time_local] "$request_method $scheme://$host$request_uri $server_protocol"
       $status $body_bytes_sent "$http_referer" "$http_user_agent"
       $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr
-      $upstream_response_length $upstream_response_time $upstream_status $req_id;
+      $upstream_response_length $upstream_response_time $upstream_status $req_id

--- a/k8s/helmfile/env/production/nginx-ingress.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/nginx-ingress.values.yaml.gotmpl
@@ -12,8 +12,8 @@ controller:
       memory: 150Mi
   config:
     block-user-agents: ~*Seekport\sCrawler.*
-    log-format-upstream: >
+    log-format-upstream: >-
       $remote_addr - $remote_user [$time_local] "$request_method $scheme://$host$request_uri $server_protocol"
       $status $body_bytes_sent "$http_referer" "$http_user_agent"
       $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr
-      $upstream_response_length $upstream_response_time $upstream_status $req_id;
+      $upstream_response_length $upstream_response_time $upstream_status $req_id

--- a/k8s/helmfile/env/staging/nginx-ingress.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/nginx-ingress.values.yaml.gotmpl
@@ -12,8 +12,8 @@ controller:
       memory: 150Mi
   config:
     block-user-agents: ~*Seekport\sCrawler.*
-    log-format-upstream: >
+    log-format-upstream: >-
       $remote_addr - $remote_user [$time_local] "$request_method $scheme://$host$request_uri $server_protocol"
       $status $body_bytes_sent "$http_referer" "$http_user_agent"
       $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr
-      $upstream_response_length $upstream_response_time $upstream_status $req_id;
+      $upstream_response_length $upstream_response_time $upstream_status $req_id


### PR DESCRIPTION
Previously this was incorrectly not stripping the
final new line resulting in a load of additional blank lines