### PR TITLE
Revert "staging: ES set action.auto_create_index: false"

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -20,7 +20,6 @@ resources:
 
 esConfig:
   elasticsearch.yml: |
-    # T309396
     xpack.ml.enabled: false
     xpack.monitoring.collection.enabled: false
     xpack.watcher.enabled: false
@@ -28,9 +27,6 @@ esConfig:
     xpack.graph.enabled: false
     xpack.logstash.enabled: false
     xpack.ccr.enabled: false
-    
-    # T309378
-    action.auto_create_index: false
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#357 -  Unable to deploy this due to the unavailability of redis charts