### PR TITLE
tf: monitoring, don't use default stats output

### DIFF
--- a/charts/stats-cron/templates/job.yaml
+++ b/charts/stats-cron/templates/job.yaml
@@ -17,5 +17,5 @@ spec:
             command:
             - /bin/sh
             - -c
-            - "OUT=$(curl --silent -H 'Accept: application/json' http://elasticsearch-master.default.svc.cluster.local:9200/_cat/nodes?format=json) && echo $OUT | jq -c '.[]'"
+            - "OUT=$(curl --silent -H 'Accept: application/json' http://elasticsearch-master.default.svc.cluster.local:9200/_cat/nodes?h=name,heap.percent,ram.percent,disk.used_percent,load_1m&format=json) && echo $OUT | jq -c '.[]'"
           restartPolicy: OnFailure

--- a/tf/modules/monitoring/variables.tf
+++ b/tf/modules/monitoring/variables.tf
@@ -15,6 +15,6 @@ variable "elasticsearch_metrics" {
       "heap.percent",
       "ram.percent",
       "disk.used_percent",
-      "load_5m"
+      "load_1m"
       ]
 }


### PR DESCRIPTION
This didn't work as expected, the disk.used_percent isn't around

Switch to using load_1m instead of 5m