### PR TITLE
staging/local: use api 0.19.13 chart

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -7,7 +7,7 @@ replicaCount:
   scheduler: 1
   queue: 1
 
-useProbes: false
+useProbes: true
 
 platform:
   backendMwHost: mediawiki-137-fp-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -123,7 +123,7 @@ releases:
 
   - name: api
     chart: wbstack/api
-    version: 0.19.12
+    version: '{{ if eq .Environment.Name "production" }}0.19.12{{ else }}0.19.13{{ end }}'
     namespace: default
     values:
       - "env/{{ .Environment.Name }}/api.values.yaml.gotmpl"


### PR DESCRIPTION
enables probes locally, these have been crashing everywhere since forever.

requires https://github.com/wbstack/charts/pull/100