### PR TITLE
production: Increase SQL memory

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -9,10 +9,10 @@ primary:
   resources:
     requests:
       cpu: 40m
-      memory: 700Mi
+      memory: 4000Mi
     limits:
       cpu: 750m
-      memory: 1000Mi
+      memory: 4300Mi
   persistence:
     enabled: true
     size: {{ .Values.services.sql.storageSize | quote }}
@@ -35,8 +35,8 @@ primary:
     # Custom
     # 16MB, default is 8MB, bitnami was 128
     key_buffer_size=16777216
-    # 67MB, default & bitnami was 134MB (134217728)
-    innodb_buffer_pool_size=67108864
+    # 2800MB (70% of 4000), default & bitnami was 134MB (134217728)
+    innodb_buffer_pool_size=2936012800
     # 8MB, default & bitnami was 16MB (16777216)
     tmp_table_size=8388608
     # 80, default & bitnami was 151
@@ -65,10 +65,10 @@ secondary:
   resources:
     requests:
       cpu: 100m
-      memory: 900Mi
+      memory: 4000Mi
     limits:
       cpu: 750m
-      memory: 1500Mi
+      memory: 4300Mi
   readinessProbe:
     enabled: true
   persistence:
@@ -93,8 +93,8 @@ secondary:
     # Custom
     # 16MB, default is 8MB, bitnami was 128
     key_buffer_size=16777216
-    # 67MB, default & bitnami was 134MB (134217728)
-    innodb_buffer_pool_size=67108864
+    # 2800MB (70% of 4000), default & bitnami was 134MB (134217728)
+    innodb_buffer_pool_size=2936012800
     # 8MB, default & bitnami was 16MB (16777216)
     tmp_table_size=8388608
     # 80, default & bitnami was 151


### PR DESCRIPTION
Increases SQL RAM to 4GB on production for primary & secondary
Also sets `innodb_buffer_pool_size` to 70% of the available memory

https://phabricator.wikimedia.org/T310782