### PR TITLE
local: update platform-nginx resources to match production

### DIFF
--- a/k8s/helmfile/env/local/platform-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/platform-nginx.values.yaml.gotmpl
@@ -5,10 +5,10 @@ replicaCount: 1
 
 resources:
   limits:
-    cpu: 40m
+    cpu: 50m
     memory: 20Mi
   requests:
-     cpu: 5m
+     cpu: 20m
      memory: 8Mi
 
 livenessProbe:


### PR DESCRIPTION
Lets not update the replica-count just yet, i think that would just make
debugging harder.