### PR TITLE
staging: update platform-nginx resources to match production

### DIFF
--- a/k8s/helmfile/env/staging/platform-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/platform-nginx.values.yaml.gotmpl
@@ -5,10 +5,10 @@ replicaCount: 2
 
 resources:
   limits:
-    cpu: 40m
+    cpu: 50m
     memory: 20Mi
   requests:
-     cpu: 5m
+     cpu: 20m
      memory: 8Mi
 
 livenessProbe:


### PR DESCRIPTION
Don't see any reason to bump replicacount