### PR TITLE
skaffold: Add `INSTALL_XDEBUG` build arg to mw

### DIFF
--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -47,6 +47,7 @@ profiles:
               LOCALIZATION_CACHE_THREAD_COUNT: 4
               LOCALIZATION_CACHE_ADDITIONAL_PARAMS: "--lang=en,sv,de"
               INSTALL_PROFILING_DEPS: 1
+              INSTALL_XDEBUG: 1
       local:
         useDockerCLI: true
     deploy:


### PR DESCRIPTION
This adds a build argument to the skaffold mediawiki config to enable xdebug

Needs https://github.com/wbstack/mediawiki/pull/264