### PR TITLE
staging: fix nginx XFF header

### DIFF
--- a/k8s/helmfile/env/local/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/local/platform-nginx.nginx.conf
@@ -30,7 +30,7 @@ server {
         # IP range matches current kubernetes pod IPs
         set_real_ip_from  10.0.0.0/14;
         real_ip_header X-Forwarded-For;
-        proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+        proxy_set_header X-Forwarded-For "$proxy_add_x_forwarded_for";
 
         client_max_body_size                    1m;
 

--- a/k8s/helmfile/env/staging/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/staging/platform-nginx.nginx.conf
@@ -30,7 +30,7 @@ server {
         # IP range matches current kubernetes pod IPs
         set_real_ip_from  10.0.0.0/14;
         real_ip_header X-Forwarded-For;
-        proxy_set_header X-Forwarded-For "$http_x_forwarded_for, $realip_remote_addr";
+        proxy_set_header X-Forwarded-For "$proxy_add_x_forwarded_for";
 
         client_max_body_size                    1m;
 


### PR DESCRIPTION
This hopefully solves the issues we experienced with https://phabricator.wikimedia.org/T309687

Uses `$proxy_add_x_forwarded_for` instead of `$http_x_forwarded_for`

From [the nginx docs](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#:~:text=protocol%E2%80%99s%20default%20port%3B-,%24proxy_add_x_forwarded_for,-the%20%E2%80%9CX%2DForwarded):
>  - `$proxy_add_x_forwarded_for`
    the `X-Forwarded-For` client request header field with the `$remote_addr` variable appended to it, separated by a comma. If the `X-Forwarded-For` field is not present in the client request header, the `$proxy_add_x_forwarded_for` variable is equal to the `$remote_addr variable`.