### PR TITLE
Remove api image tag from staging & production

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,3 +1,6 @@
+image:
+  tag: "8x.9.2"
+
 replicaCount:
   web: 1
   backend: 1

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,3 +1,6 @@
+image:
+  tag: "8x.9.3"
+
 replicaCount:
   web: 1
   backend: 1


### PR DESCRIPTION
This removes the image tag from the staging & production values files because this overrides the value from the chart