### PR TITLE
Add wiki user metrics log

### DIFF
--- a/tf/modules/monitoring/variables.tf
+++ b/tf/modules/monitoring/variables.tf
@@ -27,6 +27,10 @@ variable "platform_summary_metrics" {
       "total",
       "deleted",
       "inactive",
-      "empty"
+      "empty",
+      "total_non_deleted_users",
+      "total_non_deleted_active_users",
+      "total_non_deleted_pages",
+      "total_non_deleted_edits",
       ]
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T314128

Parse additional user metrics introduced in the API image 8x.9.5 by `PlatformStatsSummaryJob`