### PR TITLE
prod: Deploy api 8x.9.7 & ui 3.98 - display user wiki limit

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.9.6"
+  tag: "8x.9.7"
 
 replicaCount:
   web: 1

--- a/k8s/helmfile/env/production/ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ui.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "3.97"
+  tag: "3.99"
 
 resources:
   requests:


### PR DESCRIPTION
This PR deploys to production:
- ui 3.98 for https://phabricator.wikimedia.org/T315438
- api 8x.9.7 for https://phabricator.wikimedia.org/T315441

~~**do not merge before https://github.com/wmde/wbaas-deploy/pull/512 which deploys api 8x.9.6**~~