### PR TITLE
production: deploy mw  image with SFS fix

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-137-fp.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "1.37-7.4-20220812-fp-beta-0"
+  tag: "1.37-7.4-20220818-fp-beta-0"
 
 replicaCount:
   backend: 1


### PR DESCRIPTION
Production deployment PR for https://phabricator.wikimedia.org/T315594

deploys mediawiki image `1.37-7.4-20220818-fp-beta-0`