### PR TITLE
prod: deploy api v8x.9.8

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.9.7"
+  tag: "8x.9.8"
 
 replicaCount:
   web: 1


### PR DESCRIPTION
Deploys https://github.com/wbstack/api/releases/tag/8x.9.8 to **production**
https://phabricator.wikimedia.org/T315340

- Adds command to create invitation codes in bulk

