### PR TITLE
Staging: Rotate root sql password

### DIFF
--- a/tf/env/staging/kubernetes-secrets.tf
+++ b/tf/env/staging/kubernetes-secrets.tf
@@ -7,7 +7,7 @@ module "wbaas2-k8s-secrets" {
   smtp_password = random_password.smtp-password.result
   google_service_account_key_api = google_service_account_key.dev-api.private_key
   google_service_account_key_dns = google_service_account_key.certman-dns01-solver.private_key
-  sql_password_root = random_password.sql-passwords["staging-root"].result
+  sql_password_root = random_password.sql-root-password.result
   sql_password_replication = random_password.sql-passwords["staging-replication"].result
   sql_password_api = random_password.sql-passwords["staging-api"].result
   sql_password_mediawiki_db_manager = random_password.sql-passwords["staging-mediawiki-db-manager"].result

--- a/tf/env/staging/secrets-sql.tf
+++ b/tf/env/staging/secrets-sql.tf
@@ -5,3 +5,21 @@ resource "random_password" "sql-passwords" {
   special          = true
   override_special = "_%@"
 }
+
+resource "random_password" "sql-root-password" {
+  length           = 32
+  special          = true
+  override_special = "_%@"
+}
+
+resource "kubernetes_secret" "sql-root-old-secret-password" {
+  provider = kubernetes.wbaas-2
+  metadata {
+    name = "sql-root-old-secret-password"
+    namespace = "default"
+  }
+
+  binary_data = {
+    "mariadb-root-password" = base64encode(random_password.sql-passwords["staging-root"].result)
+  }
+}


### PR DESCRIPTION
This temporarally adds a new k8s secret with the old root password in so we can login to change it to the new one.
After applying this patch you must run the resetRootSqlSecretJob.

This is a reattempt of #563 with the kubernetes provider correctly set.

Bug: T321051