### PR TITLE
Prod: Rotate root sql password

### DIFF
--- a/tf/env/production/kubernetes-secrets.tf
+++ b/tf/env/production/kubernetes-secrets.tf
@@ -7,7 +7,7 @@ module "wbaas-k8s-secrets" {
   smtp_password = random_password.smtp-password.result
   google_service_account_key_api = google_service_account_key.api.private_key
   google_service_account_key_dns = google_service_account_key.certman-dns-cloud-solver.private_key
-  sql_password_root = random_password.sql-passwords["production-root"].result
+  sql_password_root = random_password.sql-root-password.result
   sql_password_replication = random_password.sql-passwords["production-replication"].result
   sql_password_api = random_password.sql-passwords["production-api"].result
   sql_password_mediawiki_db_manager = random_password.sql-passwords["production-mediawiki-db-manager"].result

--- a/tf/env/production/secrets-sql.tf
+++ b/tf/env/production/secrets-sql.tf
@@ -5,3 +5,22 @@ resource "random_password" "sql-passwords" {
   special          = true
   override_special = "_%@"
 }
+
+
+resource "random_password" "sql-root-password" {
+  length           = 32
+  special          = true
+  override_special = "_%@"
+}
+
+resource "kubernetes_secret" "sql-root-password-old" {
+  provider = kubernetes.wbaas-3
+  metadata {
+    name = "sql-root-password-old"
+    namespace = "default"
+  }
+
+  binary_data = {
+    "mariadb-root-password" = base64encode(random_password.sql-passwords["staging-root"].result)
+  }
+}


### PR DESCRIPTION
This temporarally adds a new k8s secret with the old root password in so we can login to change it to the new one.
After applying this patch you must run the resetRootSqlSecretJob.

Bug: T321051