### PR TITLE
staging: rotate non-root sql passwords

### DIFF
--- a/tf/env/staging/secrets-sql.tf
+++ b/tf/env/staging/secrets-sql.tf
@@ -5,7 +5,7 @@ resource "random_password" "sql-passwords" {
   special          = true
   override_special = "_%@"
   keepers = {
-      rotate = 1
+      rotate = 2
     }
 }
 resource "random_password" "sql-root-password" {


### PR DESCRIPTION
This is an attempt to try rotating the passwords again but hopefully keeping replication running with minimal downtime by using the job to update the replication password straight after applying this.