### PR TITLE
Use charts/wikibase-ingress in local and staging

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -116,7 +116,8 @@ releases:
 
   - name: platform-apps-ingress
     namespace: default
-    chart: ./../../charts/wikibase-ingress
+    # yamllint disable-line rule:line-length
+    chart: '{{ if eq .Environment.Name "production" }}./../../charts/wikibase-ingress{{ else }}wbstack/wikibase-ingress{{ end }}'
     values:
       - ingressNameSuffix: {{ .Values.ingressNameSuffix | toYaml }}
       - ingressHost: {{ .Values.ingressHost | toYaml }}


### PR DESCRIPTION
`platform-apps-ingress` in `local` and `staging` use `charts/wikibase-ingress` in `charts` repo. `production` one uses the chart in `wbaas-deploy` still.