### PR TITLE
k8s: prod migrate to ingress-nginx

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -1,7 +1,3 @@
-ingressNameSuffix: wikibase-production
-ingressHost: "*.wikibase-production"
-forceSSL: true
-tls: true
 controller:
   service:
     loadBalancerIP: {{ .Values.ip }}
@@ -12,6 +8,7 @@ controller:
       memory: 150Mi
   config:
     block-user-agents: ~*Seekport\sCrawler.*,~*MJ12bot.*
+    # https://stackoverflow.com/a/37877244
     log-format-upstream: >-
       $remote_addr - $remote_user [$time_local] "$request_method $scheme://$host$request_uri $server_protocol"
       $status $body_bytes_sent "$http_referer" "$http_user_agent"

--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -7,6 +7,7 @@ controller:
       cpu: 0.100
       memory: 150Mi
   config:
+    preserve-trailing-slash: true
     block-user-agents: ~*Seekport\sCrawler.*,~*MJ12bot.*
     # https://stackoverflow.com/a/37877244
     log-format-upstream: >-

--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -14,3 +14,5 @@ controller:
       $status $body_bytes_sent "$http_referer" "$http_user_agent"
       $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr
       $upstream_response_length $upstream_response_time $upstream_status $req_id
+defaultBackend:
+  enabled: true

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -81,16 +81,7 @@ releases:
   ################################
   # ALL ENVIRONMENTS
   ################################
-  - name: nginx-ingress
-    installed: {{ eq .Environment.Name "production" | toYaml }}
-    namespace: kube-system
-    chart: stable/nginx-ingress
-    version: 1.34.3
-    values:
-      - "env/{{ .Environment.Name }}/nginx-ingress.values.yaml.gotmpl"
-
   - name: ingress-nginx
-    installed: {{ ne .Environment.Name "production" | toYaml }}
     namespace: kube-system
     chart: ingress-nginx/ingress-nginx
     version: 4.2.5


### PR DESCRIPTION
This is the production counterpart to https://github.com/wmde/wbaas-deploy/pull/590

`nginx-ingress` chart usage gets removed from helmfile by this
