### PR TITLE
cleanup helmfile.yaml

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -81,14 +81,6 @@ releases:
   ################################
   # ALL ENVIRONMENTS
   ################################
-  - name: nginx-ingress
-    installed: false
-    namespace: kube-system
-    chart: stable/nginx-ingress
-    version: 1.34.3
-    values:
-      - "env/{{ .Environment.Name }}/nginx-ingress.values.yaml.gotmpl"
-
   - name: ingress-nginx
     namespace: kube-system
     chart: ingress-nginx/ingress-nginx


### PR DESCRIPTION
Removes the now unused `ingress-nginx` configuration.

Note: should only be merged if devs are aware of it in regards to their local cluster
