### PR TITLE
local: use k8s 1.22.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 minikube-start:
 	# version 1.21.4 is currently used in the production environments
-	minikube --profile minikube-wbaas start --kubernetes-version=1.21.4
+	minikube --profile minikube-wbaas start --kubernetes-version=1.22.15
 
 minikube-stop:
 	minikube --profile minikube-wbaas stop


### PR DESCRIPTION
As we are upgrading our GKE clusters to use `1.22.15-gke.1000` we also will use k8s version 1.22.15 with minikube from now on
