### PR TITLE
local: use adminer chart v0.2.1 for GA ingress handling

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -208,10 +208,10 @@ releases:
   # LOCAL ONLY
   ################################
   - name: adminer-cetic
-    installed: {{ eq .Environment.Name "local" | toYaml }}
     namespace: default
+    installed: {{ eq .Environment.Name "local" | toYaml }}
     chart: cetic/adminer
-    version: v0.1.7
+    version: v0.2.1
     values:
       - "env/{{ .Environment.Name }}/adminer-cetic.values.yaml.gotmpl"
 


### PR DESCRIPTION
This PR fixes setting up the cluster locally from scratch, see https://phabricator.wikimedia.org/T322542#8417755
