### PR TITLE
tf: fix filter for ingress-nginx logging metric

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -114,7 +114,7 @@ resource "google_logging_metric" "production-es-gc-time-seconds" {
 resource "google_logging_metric" "production-site-request-count" {
     description      = "Count of requests to sites"
     filter           = <<-EOT
-        resource.labels.container_name="ingress-nginx-controller"
+        labels."k8s-pod/app_kubernetes_io/name"="ingress-nginx"
         resource.type="k8s_container"
         -textPayload:"GoogleStackdriverMonitoring"
         -textPayload:"cert-manager"


### PR DESCRIPTION
It turns out that that container name is now just
"controller" let's target this by label instead.