### PR TITLE
tf-module-buckets-1: backup bucket retention policy

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-buckets-1
+- Re-add retention policy on backup bucket
+
 # tf-module-monitoring-15
 - Fix repeated alerts were fired for SQL replication failing
 

--- a/tf/modules/buckets/main.tf
+++ b/tf/modules/buckets/main.tf
@@ -20,6 +20,11 @@ resource "google_storage_bucket" "sql-backup" {
       age = 7
     }
   }
+
+  retention_policy {
+    is_locked = false
+    retention_period = 604800 # 7 days in seconds
+  }
 }
 
 
@@ -65,6 +70,10 @@ resource "google_storage_bucket" "static-backup" {
     }
   }
 
+  retention_policy {
+    is_locked = true
+    retention_period = 604800 # 7 days in seconds
+  }
 }
 
 # Backup bucket IAM Policy


### PR DESCRIPTION
https://phabricator.wikimedia.org/T321091

This re-adds the [retention policy](https://cloud.google.com/storage/docs/bucket-lock) to the backup bucket. 

Note: Apperantly this caused an issue with writing files to the bucket some time ago? https://github.com/wmde/wbaas-deploy/commit/fef908d315fd1ba87d9a8d2c7e1cbe2703db8ec3 

Let's use this for staging only and see if it works.

