### PR TITLE
tf-module-buckets-2: fix temporarily retention policy

### DIFF
--- a/tf/modules/buckets/main.tf
+++ b/tf/modules/buckets/main.tf
@@ -71,7 +71,7 @@ resource "google_storage_bucket" "static-backup" {
   }
 
   retention_policy {
-    is_locked = true
+    is_locked = false
     retention_period = 604800 # 7 days in seconds
   }
 }


### PR DESCRIPTION
A fix for the faulty `tf-module-buckets-1`: https://github.com/wmde/wbaas-deploy/pull/608

We wanted to keep the retention policy unlocked for testing this out.

