### PR TITLE
tf-module-buckets: remove retention policy again

### DIFF
--- a/tf/modules/buckets/main.tf
+++ b/tf/modules/buckets/main.tf
@@ -20,11 +20,6 @@ resource "google_storage_bucket" "sql-backup" {
       age = 7
     }
   }
-
-  retention_policy {
-    is_locked = false
-    retention_period = 604800 # 7 days in seconds
-  }
 }
 
 
@@ -68,11 +63,6 @@ resource "google_storage_bucket" "static-backup" {
     condition {
       days_since_noncurrent_time = 7
     }
-  }
-
-  retention_policy {
-    is_locked = false
-    retention_period = 604800 # 7 days in seconds
   }
 }
 


### PR DESCRIPTION
Removes the backup bucket retention policy again, because we can't use it yet, see https://phabricator.wikimedia.org/T321091#8470662


