### PR TITLE
k8s: add ingress.class annotation to mailhog Ingress

### DIFF
--- a/k8s/helmfile/env/local/mailhog.values.yaml
+++ b/k8s/helmfile/env/local/mailhog.values.yaml
@@ -5,5 +5,7 @@ ingress:
       paths:
         - path: /
           pathType: Prefix
+  annotations:
+    kubernetes.io/ingress.class: nginx
 serviceAccount:
   create: false


### PR DESCRIPTION
Since changing to ingress-nginx this is now needed in order for the controller to handle this ingress