### PR TITLE
prod: Bump follow-redirects and express

### DIFF
--- a/k8s/helmfile/env/production/ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ui.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "sha-3f36262"
+  tag: "sha-d348d8e"
 
 resources:
   requests:


### PR DESCRIPTION
Bump follow-redirects from 1.13.2 to 1.15.2
Bump express from 4.17.1 to 4.18.2

Bug: T325345 Bug: T325350