### PR TITLE
Revert "k8s: prod: increase sql storage size to 120GB"

### DIFF
--- a/k8s/helmfile/env/production/private.yaml
+++ b/k8s/helmfile/env/production/private.yaml
@@ -29,7 +29,7 @@ services:
           - /api(/|$)(.*)
   sql:
     storageClass: premium-rwo
-    storageSize: 120Gi
+    storageSize: 60Gi
     api:
       db: apidb
       user: apiuser


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#636
```
Error: UPGRADE FAILED: cannot patch "sql-mariadb-primary" with kind StatefulSet: StatefulSet.apps "sql-mariadb-primary" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy' and 'minReadySeconds' are forbidden && cannot patch "sql-mariadb-secondary" with kind StatefulSet: StatefulSet.apps "sql-mariadb-secondary" is invalid: spec: Forbidden: updates to statefulset spec for fields other than 'replicas', 'template', 'updateStrategy' and 'minReadySeconds' are forbidden
make: *** [Makefile:87: apply-production] Error 1
```