### PR TITLE
fix: "double quotes" break json payload being sent to mattermost hook

### DIFF
--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -11,7 +11,7 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
           HTML_LINK: ${{ github.event.pull_request.html_url }}
         run: >
-          echo "{\"text\":\"Pull request opened: [$(printf "%q" $TITLE)](${HTML_LINK}\"}"
+          echo "{\"text\":\"Pull request opened: [$(printf "%q" $TITLE)](${HTML_LINK})\"}"
           > mattermost.json
       - uses: mattermost/action-mattermost-notify@master
         env:

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -11,7 +11,7 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
           HTML_LINK: ${{ github.event.pull_request.html_url }}
         run: >
-          echo "{\"text\":\"Pull request opened: [$(printf "%q" "$TITLE")](${HTML_LINK})\"}"
+          jq -n --arg t "Pull request opened: [${TITLE}](${HTML_LINK})" '{text: $t}'
           > mattermost.json
       - uses: mattermost/action-mattermost-notify@master
         env:

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -9,9 +9,9 @@ jobs:
       - name: Create the Mattermost Message
         env:
           TITLE: ${{ github.event.pull_request.title }}
-          HTML_LINK: ${{github.event.pull_request.html_url }}
+          HTML_LINK: ${{ github.event.pull_request.html_url }}
         run: >
-          echo "{\"text\":\"Pull request opened: [${TITLE}](${HTML_LINK})\"}"
+          echo "{\"text\":\"Pull request opened: [$(printf "%q" $TITLE)](${HTML_LINK}\"}"
           > mattermost.json
       - uses: mattermost/action-mattermost-notify@master
         env:

--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -11,7 +11,7 @@ jobs:
           TITLE: ${{ github.event.pull_request.title }}
           HTML_LINK: ${{ github.event.pull_request.html_url }}
         run: >
-          echo "{\"text\":\"Pull request opened: [$(printf "%q" $TITLE)](${HTML_LINK})\"}"
+          echo "{\"text\":\"Pull request opened: [$(printf "%q" "$TITLE")](${HTML_LINK})\"}"
           > mattermost.json
       - uses: mattermost/action-mattermost-notify@master
         env:


### PR DESCRIPTION
When processing a PR title containing double quotes we construct invalid JSON as these double quotes are never escaped. Instead, escape the title using `jq`.

E.g.: https://github.com/wmde/wbaas-deploy/pull/638