### PR TITLE
chore(helm): remove deprecated charts.helm.sh repository

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -1,7 +1,4 @@
 repositories:
-    # This is now deprecated remove once no longer used
-  - name: stable
-    url: https://charts.helm.sh/stable
   - name: wbstack
     url: https://wbstack.github.io/charts
   - name: bitnami


### PR DESCRIPTION
This PR picks up a comment in the code, the `stable` repository is not in use anymore since 5aa26b22b3785fa7f0c215162ddbda9e86bcdc56

Considering we `add` these very often in development, it's probably nice to keep them tidy.