### PR TITLE
refactor(makefile): use same commands for envs and modules, add help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,11 +44,17 @@ minikube-tunnel: # @HELP Open a tunnel to the local cluster and expose it on an 
 minikube-tunnel:
 	./bin/minikube-tunnel
 
+.PHONY: helmfile-fetch
+helmfile-fetch: # @HELP Fetch all charts defined in the Helmfile. This works across all environments
+helmfile-fetch:
+# local environment is used (as one is needed), and any will do
+	cd ./k8s/helmfile && helmfile --environment local fetch
+
 .PHONY: helmfile-deps
 helmfile-deps: # @HELP Fetch all deps defined in the Helmfile. This works across all environments
 helmfile-deps:
 # local environment is used (as one is needed), and any will do
-	cd ./k8s/helmfile && helmfile --environment local fetch
+	cd ./k8s/helmfile && helmfile --environment local deps
 
 PHONY: init-%
 init-local: # @HELP Initialize terraform state for your local setup. This does not create any resources

--- a/Makefile
+++ b/Makefile
@@ -1,95 +1,105 @@
-.PHONY: minikube-start minikube-stop minikube-delete minikube-dashboard minikube-tunnel init-local init-staging init-production
+.PHONY: help
+help: # @HELP Print this message
+help:
+	@echo "TARGETS:"
+	@grep -E '^.*: *# *@HELP' $(MAKEFILE_LIST)    \
+	    | awk '                                   \
+	        BEGIN {FS = ": *# *@HELP"};           \
+	        { printf "  %-20s %s\n", $$1, $$2 };  \
+	    '
 
+.PHONY: minikube-start
+minikube-start: # @HELP Start a local k8s cluster using minikube
 minikube-start:
-	# version 1.21.4 is currently used in the production environments
+# version 1.21.4 is currently used in the production environments
 	minikube --profile minikube-wbaas start --kubernetes-version=1.22.15
 
+.PHONY: minikube-stop
+minikube-stop: # @HELP Stop the local minikube cluster
 minikube-stop:
 	minikube --profile minikube-wbaas stop
 
+.PHONY: minikube-delete
+minikube-delete: # @HELP Delete the local minikube cluster
 minikube-delete:
 	minikube --profile minikube-wbaas delete
 
-minikube-dashboard:
-	minikube --profile minikube-wbaas dashboard
-
+.PHONY: minikube-pause
+minikube-pause: # @HELP Pause the local minikube cluster
 minikube-pause:
 	minikube --profile minikube-wbaas pause -A
 
+.PHONY: minikube-unpause
+minikube-unpause: # @HELP Pause the local minikube cluster
 minikube-unpause:
 	minikube --profile minikube-wbaas unpause -A
 
+.PHONY: minikube-dashboard
+minikube-dashboard: # @HELP Open the Kubernetes Dashboard for your local cluster in your browser
+minikube-dashboard:
+	minikube --profile minikube-wbaas dashboard
+
+.PHONY: minikube-tunnel
+minikube-tunnel: # @HELP Open a tunnel to the local cluster and expose it on an IP on the host system
 minikube-tunnel:
 	./bin/minikube-tunnel
 
 .PHONY: helmfile-deps
-
-# Fetch all deps defined in the helmfile.
-# local environment is used (as one is needed), and any will do
+helmfile-deps: # @HELP Fetch all deps defined in the Helmfile. This works across all environments
 helmfile-deps:
+# local environment is used (as one is needed), and any will do
 	cd ./k8s/helmfile && helmfile --environment local fetch
 
-.PHONY: diff-local apply-local
-diff-local:
-	cd ./tf/env/local && terraform plan
-	cd ./k8s/helmfile && helmfile --environment local diff --context 5
-apply-local:
-	cd ./tf/env/local && terraform apply
-	cd ./k8s/helmfile && helmfile --environment local --interactive apply --context 5
+PHONY: init-%
+init-local: # @HELP Initialize terraform state for your local setup. This does not create any resources
+init-staging: # @HELP Initialize terraform state for staging. This does not create any resources
+init-production: # @HELP Initialize terraform state for production. This does not create any resources
+init-%: ENV=$*
+init-%:
+	cd ./tf/env/$(ENV) && terraform init
 
-init:
-	cd ./tf/env/${ENVIRONMENT} && terraform init
-init-local:
-	ENVIRONMENT=local make init
-init-staging:
-	ENVIRONMENT=staging make init
-init-production:
-	ENVIRONMENT=production make init
+.PHONY: diff-%
+diff-local: # @HELP Diff the repository against the state of your local cluster
+diff-staging: # @HELP Diff the repository against the state of the staging cluster
+diff-production: # @HELP Diff the repository against the state of the production cluster
+diff-%: ENV=$*
+diff-%:
+	cd ./tf/env/$(ENV) && terraform plan
+	cd ./k8s/helmfile && helmfile --environment $(ENV) diff --context 5
 
-.PHONY: skaffold skaffold-mediawiki skaffold-ui
-skaffold:
-	cd ./skaffold && skaffold run -m ${MODULE}
-skaffold-mediawiki:
-	MODULE=mediawiki-137-fp make skaffold
-skaffold-ui:
-	MODULE=ui make skaffold
-skaffold-api:
-	MODULE=api make skaffold
-skaffold-queryservice:
-	MODULE=queryservice make skaffold
-skaffold-queryservice-ui:
-	MODULE=queryservice-ui make skaffold
-skaffold-queryservice-updater:
-	MODULE=queryservice-updater make skaffold
-skaffold-queryservice-gateway:
-	MODULE=queryservice-gateway make skaffold
+.PHONY: apply-%
+apply-local: # @HELP Apply changes in the repository to your local cluster
+apply-staging: # @HELP Apply changes in the repository to the staging cluster
+apply-production: # @HELP Apply changes in the repository to the production cluster
+apply-%: ENV=$*
+apply-%:
+	cd ./tf/env/$(ENV) && terraform apply
+	cd ./k8s/helmfile && helmfile --environment $(ENV) --interactive apply --context 5
 
-.PHONY: diff apply
+diff: # @HELP Run diff for both staging and production
 diff: diff-staging diff-production
+apply: # @HELP Run apply for both staging and production
 apply: apply-staging apply-production
 
-.PHONY: diff-staging apply-staging
-diff-staging:
-	cd ./tf/env/staging && terraform plan
-	cd ./k8s/helmfile && helmfile --environment staging diff --context 5
-# Note: the staging command here actually terraform applies all of staging
-apply-staging:
-	cd ./tf/env/staging && terraform apply
-	cd ./k8s/helmfile && helmfile --environment staging --interactive apply --context 5
-
-.PHONY: diff-production apply-production
-diff-production:
-	cd ./tf/env/production && terraform plan
-	cd ./k8s/helmfile && helmfile --environment production diff --context 5
-# Note: the production command here actually terraform applies all of production
-apply-production:
-	cd ./tf/env/production && terraform apply
-	cd ./k8s/helmfile && helmfile --environment production --interactive apply --context 5
-
-.PHONY: skaffold-run
-skaffold-run:
-	cd ./skaffold && skaffold run --kube-context minikube-wbaas
-
 .PHONY: test
+test: # @HELP Run yamllint tests against the repsoitory
 test:
 	yamllint --no-warnings .
+
+skaffold-mediawiki: skaffold-mediawiki-137-fp
+skaffold-mediawiki: # @HELP Run the local mediawiki module using skaffold
+skaffold-ui: # @HELP Run the local ui module using skaffold
+skaffold-api: # @HELP Run the api module using skaffold
+skaffold-queryservice: # @HELP  Run the local queryservice module using skaffold
+skaffold-queryservice-ui: # @HELP Run the local queryservice-ui module using skaffold
+skaffold-queryservice-updater: # @HELP Run the local queryservice-updater module using skaffold
+skaffold-queryservice-gateway: # @HELP Run the local queryservice-gateway module using skaffold
+.PHONY: skaffold-%
+skaffold-%: MODULE=$*
+skaffold-%:
+	cd ./skaffold && skaffold run -m $(MODULE)
+
+.PHONY: skaffold-run
+skaffold-run: # @HELP Run all local modules using skaffold
+skaffold-run:
+	cd ./skaffold && skaffold run --kube-context minikube-wbaas

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ help:
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube
 minikube-start:
-# version 1.21.4 is currently used in the production environments
 	minikube --profile minikube-wbaas start --kubernetes-version=1.22.15
 
 .PHONY: minikube-stop
@@ -93,17 +92,17 @@ test:
 	yamllint --no-warnings .
 
 skaffold-mediawiki: skaffold-mediawiki-137-fp
-skaffold-mediawiki: # @HELP Run the local mediawiki module using skaffold
-skaffold-ui: # @HELP Run the local ui module using skaffold
-skaffold-api: # @HELP Run the api module using skaffold
-skaffold-queryservice: # @HELP  Run the local queryservice module using skaffold
-skaffold-queryservice-ui: # @HELP Run the local queryservice-ui module using skaffold
-skaffold-queryservice-updater: # @HELP Run the local queryservice-updater module using skaffold
-skaffold-queryservice-gateway: # @HELP Run the local queryservice-gateway module using skaffold
+skaffold-mediawiki: # @HELP Deploy the local mediawiki image using skaffold
+skaffold-ui: # @HELP Deploy the local ui image using skaffold
+skaffold-api: # @HELP Deploy the api image using skaffold
+skaffold-queryservice: # @HELP  Deploy the local queryservice image using skaffold
+skaffold-queryservice-ui: # @HELP Deploy the local queryservice-ui image using skaffold
+skaffold-queryservice-updater: # @HELP Deploy the local queryservice-updater image using skaffold
+skaffold-queryservice-gateway: # @HELP Deploy the local queryservice-gateway image using skaffold
 .PHONY: skaffold-%
 skaffold-%: MODULE=$*
 skaffold-%:
-	cd ./skaffold && skaffold run -m $(MODULE)
+	cd ./skaffold && skaffold run --kube-context minikube-wbaas -m $(MODULE)
 
 .PHONY: skaffold-run
 skaffold-run: # @HELP Run all local modules using skaffold

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ minikube-pause:
 	minikube --profile minikube-wbaas pause -A
 
 .PHONY: minikube-unpause
-minikube-unpause: # @HELP Pause the local minikube cluster
+minikube-unpause: # @HELP Unpause the local minikube cluster
 minikube-unpause:
 	minikube --profile minikube-wbaas unpause -A
 
@@ -57,9 +57,9 @@ helmfile-deps:
 	cd ./k8s/helmfile && helmfile --environment local deps
 
 PHONY: init-%
-init-local: # @HELP Initialize terraform state for your local setup. This does not create any resources
-init-staging: # @HELP Initialize terraform state for staging. This does not create any resources
-init-production: # @HELP Initialize terraform state for production. This does not create any resources
+init-local: # @HELP Initialize terraform state for your local setup. This does not create any resources. It also downloads any new modules
+init-staging: # @HELP Initialize terraform state for staging. This does not create any resources. It also downloads any new modules
+init-production: # @HELP Initialize terraform state for production. This does not create any resources. It also downloads any new modules
 init-%: ENV=$*
 init-%:
 	cd ./tf/env/$(ENV) && terraform init
@@ -88,7 +88,7 @@ apply: # @HELP Run apply for both staging and production
 apply: apply-staging apply-production
 
 .PHONY: test
-test: # @HELP Run yamllint tests against the repsoitory
+test: # @HELP Run yamllint tests against the repository
 test:
 	yamllint --no-warnings .
 


### PR DESCRIPTION
This is an attempt at cleaning up the Makefile which mostly aims at me better understanding what the targets do.

Things that have been changed:
- A mechanism for displaying help is added. This means that `make` or `make help` will blurt out some text like this:
  ```
  TARGETS:
  help                  Print this message
  minikube-start        Start a local k8s cluster using minikube
  minikube-stop         Stop the local minikube cluster
  minikube-delete       Delete the local minikube cluster
  minikube-pause        Pause the local minikube cluster
  minikube-unpause      Unpause the local minikube cluster
  minikube-dashboard    Open the Kubernetes Dashboard for your local cluster in your browser
  minikube-tunnel       Open a tunnel to the local cluster and expose it on an IP on the host system
  helmfile-fetch        Fetch all charts defined in the Helmfile. This works across all environments
  helmfile-deps         Fetch all deps defined in the Helmfile. This works across all environments
  init-local            Initialize terraform state for your local setup. This does not create any resources. It also downloads any new modules
  init-staging          Initialize terraform state for staging. This does not create any resources. It also downloads any new modules
  init-production       Initialize terraform state for production. This does not create any resources. It also downloads any new modules
  diff-local            Diff the repository against the state of your local cluster
  diff-staging          Diff the repository against the state of the staging cluster
  diff-production       Diff the repository against the state of the production cluster
  apply-local           Apply changes in the repository to your local cluster
  apply-staging         Apply changes in the repository to the staging cluster
  apply-production      Apply changes in the repository to the production cluster
  diff                  Run diff for both staging and production
  apply                 Run apply for both staging and production
  test                  Run yamllint tests against the repository
  skaffold-mediawiki    Deploy the local mediawiki image using skaffold
  skaffold-ui           Deploy the local ui image using skaffold
  skaffold-api          Deploy the api image using skaffold
  skaffold-queryservice   Deploy the local queryservice image using skaffold
  skaffold-queryservice-ui  Deploy the local queryservice-ui image using skaffold
  skaffold-queryservice-updater  Deploy the local queryservice-updater image using skaffold
  skaffold-queryservice-gateway  Deploy the local queryservice-gateway image using skaffold
  skaffold-run          Run all local modules using skaffold
  ```
- Targets that use an environment name (e.g. local, staging, production) now run off the same code. The desired targets are still available in tab autocompletion as they are defined for help content.
