### PR TITLE
refactor(helm): elasticsearch values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/elasticsearch.values.yaml.gotmpl
@@ -1,0 +1,23 @@
+image: "wikibase/elasticsearch"
+imageTag: "6.8.23-wmde.6"
+imagePullPolicy: Always
+
+replicas: 3
+minimumMasterNodes: 2
+
+# For now we don't have enough nodes to have this set to hard
+antiAffinity: soft
+
+esConfig:
+  elasticsearch.yml: |
+    # T309396
+    xpack.ml.enabled: false
+    xpack.monitoring.collection.enabled: false
+    xpack.watcher.enabled: false
+    xpack.security.enabled: false
+    xpack.graph.enabled: false
+    xpack.logstash.enabled: false
+    xpack.ccr.enabled: false
+
+    # T309378
+    action.auto_create_index: false

--- a/k8s/helmfile/env/common/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/elasticsearch.values.yaml.gotmpl
@@ -1,5 +1,4 @@
 image: "wikibase/elasticsearch"
-imageTag: "6.8.23-wmde.6"
 imagePullPolicy: Always
 
 replicas: 3

--- a/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
@@ -1,3 +1,5 @@
+imageTag: "6.8.23-wmde.6"
+
 esJavaOpts: "-Xms1g -Xmx1g"
 
 resources:

--- a/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
@@ -1,13 +1,3 @@
-image: "wikibase/elasticsearch"
-imageTag: "6.8.23-wmde.6"
-imagePullPolicy: Always
-
-replicas: 3
-minimumMasterNodes: 2
-
-# For now we don't have enough nodes to have this set to hard
-antiAffinity: soft
-
 esJavaOpts: "-Xms1g -Xmx1g"
 
 resources:
@@ -17,20 +7,6 @@ resources:
   limits:
     cpu: "1000m"
     memory: "1.5Gi"
-
-esConfig:
-  elasticsearch.yml: |
-    # T309396
-    xpack.ml.enabled: false
-    xpack.monitoring.collection.enabled: false
-    xpack.watcher.enabled: false
-    xpack.security.enabled: false
-    xpack.graph.enabled: false
-    xpack.logstash.enabled: false
-    xpack.ccr.enabled: false
-
-    # T309378
-    action.auto_create_index: false
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]

--- a/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
@@ -1,3 +1,5 @@
+imageTag: "6.8.23-wmde.6"
+
 esJavaOpts: "-Xms4g -Xmx4g"
 
 resources:

--- a/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
@@ -1,13 +1,3 @@
-image: "wikibase/elasticsearch"
-imageTag: "6.8.23-wmde.6"
-imagePullPolicy: Always
-
-replicas: 3
-minimumMasterNodes: 2
-
-# For now we don't have enough nodes to have this set to hard
-antiAffinity: soft
-
 esJavaOpts: "-Xms4g -Xmx4g"
 
 resources:
@@ -17,20 +7,6 @@ resources:
   limits:
     cpu: "3950m"
     memory: "8Gi"
-
-esConfig:
-  elasticsearch.yml: |
-    # T309396
-    xpack.ml.enabled: false
-    xpack.monitoring.collection.enabled: false
-    xpack.watcher.enabled: false
-    xpack.security.enabled: false
-    xpack.graph.enabled: false
-    xpack.logstash.enabled: false
-    xpack.ccr.enabled: false
-
-    # T309378
-    action.auto_create_index: false
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]

--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,13 +1,3 @@
-image: "wikibase/elasticsearch"
-imageTag: "6.8.23-wmde.6"
-imagePullPolicy: Always
-
-replicas: 3
-minimumMasterNodes: 2
-
-# For now we don't have enough nodes to have this set to hard
-antiAffinity: soft
-
 esJavaOpts: "-Xms2g -Xmx2g"
 
 resources:
@@ -17,20 +7,6 @@ resources:
   limits:
     cpu: "1950m"
     memory: "4Gi"
-
-esConfig:
-  elasticsearch.yml: |
-    # T309396
-    xpack.ml.enabled: false
-    xpack.monitoring.collection.enabled: false
-    xpack.watcher.enabled: false
-    xpack.security.enabled: false
-    xpack.graph.enabled: false
-    xpack.logstash.enabled: false
-    xpack.ccr.enabled: false
-    
-    # T309378
-    action.auto_create_index: false
 
 volumeClaimTemplate:
   accessModes: [ "ReadWriteOnce" ]

--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,3 +1,5 @@
+imageTag: "6.8.23-wmde.6"
+
 esJavaOpts: "-Xms2g -Xmx2g"
 
 resources:


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of elasticsearch and uses the same common config for all environments.

This state diffs cleanly against local, staging and production.