### PR TITLE
refactor(helm): redis values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/redis.values.yaml.gotmpl
@@ -1,0 +1,27 @@
+redisPort: 6379
+architecture: "replication"
+sentinel:
+  enabled: false
+auth:
+  enabled: true
+  existingSecret: redis-password
+  existingSecretPasswordKey: password
+
+master:
+  persistence:
+    enabled: true
+    path: /data
+    subPath: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+
+replica:
+  replicaCount: 1
+  persistence:
+    enabled: true
+    path: /data
+    subPath: ""
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi

--- a/k8s/helmfile/env/local/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/redis.values.yaml.gotmpl
@@ -1,11 +1,3 @@
-redisPort: 6379
-architecture: "replication"
-sentinel:
-  enabled: false
-auth:
-  enabled: true
-  existingSecret: redis-password
-  existingSecretPasswordKey: password
 commonConfiguration: |
   # Enable AOF https://redis.io/topics/persistence#append-only-file
   appendonly yes
@@ -31,20 +23,12 @@ master:
     limits:
       cpu: 50m
       memory: 90Mi
-  persistence:
-    enabled: true
-    path: /data
-    subPath: ""
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi
 
 replica:
   livenessProbe:
     enabled: false
   readinessProbe:
     enabled: false
-  replicaCount: 1
   resources:
     requests:
       cpu: 10m
@@ -54,10 +38,3 @@ replica:
     limits:
       cpu: 50m
       memory: 90Mi
-  persistence:
-    enabled: true
-    path: /data
-    subPath: ""
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi

--- a/k8s/helmfile/env/production/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/redis.values.yaml.gotmpl
@@ -1,11 +1,3 @@
-redisPort: 6379
-architecture: "replication"
-sentinel:
-  enabled: false
-auth:
-  enabled: true
-  existingSecret: redis-password
-  existingSecretPasswordKey: password
 commonConfiguration: |
   # Enable AOF https://redis.io/topics/persistence#append-only-file
   appendonly yes
@@ -17,7 +9,10 @@ commonConfiguration: |
   # Auto AOF file rewriting
   auto-aof-rewrite-percentage 100
   auto-aof-rewrite-min-size 85mb
+
 master:
+  persistence:
+    storageClass: premium-rwo
   resources:
     requests:
       cpu: 100m
@@ -26,16 +21,10 @@ master:
     limits:
       cpu: 200m
       memory: 150Mi
-  persistence:
-    enabled: true
-    path: /data
-    subPath: ""
-    storageClass: premium-rwo
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi
+
 replica:
-  replicaCount: 1
+  persistence:
+    storageClass: premium-rwo
   resources:
     requests:
       cpu: 40m
@@ -43,11 +32,3 @@ replica:
     limits:
       cpu: 80m
       memory: 150Mi
-  persistence:
-    enabled: true
-    path: /data
-    subPath: ""
-    storageClass: premium-rwo
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi

--- a/k8s/helmfile/env/staging/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/redis.values.yaml.gotmpl
@@ -1,11 +1,3 @@
-redisPort: 6379
-architecture: "replication"
-sentinel:
-  enabled: false
-auth:
-  enabled: true
-  existingSecret: redis-password
-  existingSecretPasswordKey: password
 commonConfiguration: |
   # Enable AOF https://redis.io/topics/persistence#append-only-file
   appendonly yes
@@ -17,7 +9,10 @@ commonConfiguration: |
   # Auto AOF file rewriting
   auto-aof-rewrite-percentage 100
   auto-aof-rewrite-min-size 85mb
+
 master:
+  persistence:
+    storageClass: premium-rwo
   resources:
     requests:
       cpu: 100m
@@ -26,15 +21,10 @@ master:
     limits:
       cpu: 200m
       memory: 150Mi
-  persistence:
-    enabled: true
-    path: /data
-    subPath: ""
-    storageClass: premium-rwo
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi
+
 replica:
+  persistence:
+    storageClass: premium-rwo
   replicaCount: 1
   resources:
     requests:
@@ -43,11 +33,3 @@ replica:
     limits:
       cpu: 80m
       memory: 150Mi
-  persistence:
-    enabled: true
-    path: /data
-    subPath: ""
-    storageClass: premium-rwo
-    accessModes:
-      - ReadWriteOnce
-    size: 1Gi


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of redis and uses the same common config for all environments.

This state diffs cleanly against local, staging and production.