### PR TITLE
refactor(helm): tool-cradle|widar|quickstatements values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/tool-cradle.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/tool-cradle.values.yaml.gotmpl
@@ -1,5 +1,8 @@
+replicaCount: 1
+
 image:
-  tag: "2.0.1"
+  repository: ghcr.io/wbstack/cradle
+  pullPolicy: Always
 
 resources:
   requests:

--- a/k8s/helmfile/env/common/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/tool-quickstatements.values.yaml.gotmpl
@@ -1,0 +1,14 @@
+replicaCount: 1
+
+platform:
+  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
+php:
+  sessionSaveHandler: redis
+  sessionSavePath:
+  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
+  sessionSaveRedisPort: {{ .Values.services.redis.port }}
+  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolQuickstatements }}
+  sessionSaveRedisAuth:
+  sessionSaveRedisAuthSecretName: redis-password
+  sessionSaveRedisAuthSecretKey: password
+  sessionSaveRedisPrefix: "session_quickstatements_"

--- a/k8s/helmfile/env/common/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/tool-widar.values.yaml.gotmpl
@@ -1,0 +1,14 @@
+replicaCount: 1
+
+platform:
+  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
+php:
+  sessionSaveHandler: redis
+  sessionSavePath:
+  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
+  sessionSaveRedisPort: {{ .Values.services.redis.port }}
+  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolWidar }}
+  sessionSaveRedisAuth:
+  sessionSaveRedisAuthSecretName: redis-password
+  sessionSaveRedisAuthSecretKey: password
+  sessionSaveRedisPrefix: "session_widar_"

--- a/k8s/helmfile/env/local/tool-cradle.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/tool-cradle.values.yaml.gotmpl
@@ -1,9 +1,3 @@
-replicaCount: 1
-
-image:
-  repository: ghcr.io/wbstack/cradle
-  tag: "2.0.1"
-  pullPolicy: Always
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/local/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/tool-quickstatements.values.yaml.gotmpl
@@ -1,20 +1,6 @@
-replicaCount: 1
-
-platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-php:
-  sessionSaveHandler: redis
-  sessionSavePath:
-  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
-  sessionSaveRedisPort: {{ .Values.services.redis.port }}
-  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolQuickstatements }}
-  sessionSaveRedisAuth:
-  sessionSaveRedisAuthSecretName: redis-password
-  sessionSaveRedisAuthSecretKey: password
-  sessionSaveRedisPrefix: "session_quickstatements_"
-
 image:
   pullPolicy: IfNotPresent
+
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/local/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/tool-widar.values.yaml.gotmpl
@@ -1,18 +1,3 @@
-replicaCount: 1
-
-platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-php:
-  sessionSaveHandler: redis
-  sessionSavePath:
-  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
-  sessionSaveRedisPort: {{ .Values.services.redis.port }}
-  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolWidar }}
-  sessionSaveRedisAuth:
-  sessionSaveRedisAuthSecretName: redis-password
-  sessionSaveRedisAuthSecretKey: password
-  sessionSaveRedisPrefix: "session_widar_"
-
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
@@ -1,18 +1,3 @@
-replicaCount: 1
-
-platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-php:
-  sessionSaveHandler: redis
-  sessionSavePath:
-  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
-  sessionSaveRedisPort: {{ .Values.services.redis.port }}
-  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolQuickstatements }}
-  sessionSaveRedisAuth:
-  sessionSaveRedisAuthSecretName: redis-password
-  sessionSaveRedisAuthSecretKey: password
-  sessionSaveRedisPrefix: "session_quickstatements_"
-
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
@@ -1,18 +1,3 @@
-replicaCount: 1
-
-platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-php:
-  sessionSaveHandler: redis
-  sessionSavePath:
-  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
-  sessionSaveRedisPort: {{ .Values.services.redis.port }}
-  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolWidar }}
-  sessionSaveRedisAuth:
-  sessionSaveRedisAuthSecretName: redis-password
-  sessionSaveRedisAuthSecretKey: password
-  sessionSaveRedisPrefix: "session_widar_"
-
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/staging/tool-cradle.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-cradle.values.yaml.gotmpl
@@ -1,9 +1,6 @@
-replicaCount: 1
-
 image:
-  repository: ghcr.io/wbstack/cradle
   tag: "2.0.1"
-  pullPolicy: Always
+
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/staging/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-quickstatements.values.yaml.gotmpl
@@ -1,18 +1,3 @@
-replicaCount: 1
-
-platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-php:
-  sessionSaveHandler: redis
-  sessionSavePath:
-  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
-  sessionSaveRedisPort: {{ .Values.services.redis.port }}
-  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolQuickstatements }}
-  sessionSaveRedisAuth:
-  sessionSaveRedisAuthSecretName: redis-password
-  sessionSaveRedisAuthSecretKey: password
-  sessionSaveRedisPrefix: "session_quickstatements_"
-
 resources:
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/staging/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-widar.values.yaml.gotmpl
@@ -1,18 +1,3 @@
-replicaCount: 1
-
-platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-php:
-  sessionSaveHandler: redis
-  sessionSavePath:
-  sessionSaveRedisHost: {{ .Values.services.redis.writeHost }}
-  sessionSaveRedisPort: {{ .Values.services.redis.port }}
-  sessionSaveRedisDatabase: {{ .Values.services.redis.databases.toolWidar }}
-  sessionSaveRedisAuth:
-  sessionSaveRedisAuthSecretName: redis-password
-  sessionSaveRedisAuthSecretKey: password
-  sessionSaveRedisPrefix: "session_widar_"
-
 resources:
   requests:
     cpu: 1m


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of tool-cradle|widar|quickstatements and uses the same common config for all environments.

This state diffs cleanly against local, staging and production.