### PR TITLE
refactor(helm): queryservice-ui|gateway|updater values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/queryservice-gateway.values.yaml.gotmpl
@@ -1,0 +1,6 @@
+platform:
+  apiBackendHost: api-app-backend.default.svc.cluster.local
+
+image:
+  repository: ghcr.io/wbstack/queryservice-gateway
+  pullPolicy: Always

--- a/k8s/helmfile/env/common/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/queryservice-updater.values.yaml.gotmpl
@@ -1,0 +1,11 @@
+replicaCount: 1
+
+image:
+  repository: ghcr.io/wbstack/queryservice-updater
+  pullPolicy: Always
+
+app:
+  sleepTime: 5
+  loopLimit: 100
+  getBatchesEndpoint: http://api-app-backend.default.svc.cluster.local/backend/qs/getBatches
+  wikibaseScheme: http

--- a/k8s/helmfile/env/common/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/queryservice.values.yaml.gotmpl
@@ -1,0 +1,8 @@
+image:
+  repository: ghcr.io/wbstack/queryservice
+  pullPolicy: Always
+
+persistence:
+  enabled: true
+  annotations: {}
+  accessMode: ReadWriteOnce

--- a/k8s/helmfile/env/local/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice-gateway.values.yaml.gotmpl
@@ -1,5 +1,3 @@
-platform:
-  apiBackendHost: api-app-backend.default.svc.cluster.local
 resources:
   requests:
     cpu: 60m
@@ -7,7 +5,6 @@ resources:
   limits:
     cpu: 100m
     memory: 100Mi
+
 image:
-  repository: ghcr.io/wbstack/queryservice-gateway
   tag: "2.1"
-  pullPolicy: Always

--- a/k8s/helmfile/env/local/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice-updater.values.yaml.gotmpl
@@ -1,9 +1,3 @@
-replicaCount: 1
-app:
-  sleepTime: 5
-  loopLimit: 100
-  getBatchesEndpoint: http://api-app-backend.default.svc.cluster.local/backend/qs/getBatches
-  wikibaseScheme: http
 resources:
   requests:
     cpu: 80m

--- a/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
@@ -1,10 +1,11 @@
 image:
-  repository: ghcr.io/wbstack/queryservice
   tag: "0.3.6_0.6"
-  pullPolicy: Always
+
 useProbes: false
+
 app:
   heapSize: 1g
+
 resources:
   requests:
     cpu: 0.1
@@ -12,9 +13,7 @@ resources:
   limits:
     cpu: 0.5
     memory: "2072Mi"
+
 persistence:
-  enabled: true
-  accessMode: ReadWriteOnce
   storageClass: "standard"
   size: "1Gi"
-  annotations: {}

--- a/k8s/helmfile/env/production/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-gateway.values.yaml.gotmpl
@@ -1,5 +1,3 @@
-platform:
-  apiBackendHost: api-app-backend.default.svc.cluster.local
 resources:
   requests:
     cpu: 60m
@@ -7,7 +5,6 @@ resources:
   limits:
     cpu: 100m
     memory: 100Mi
+
 image:
-  repository: ghcr.io/wbstack/queryservice-gateway
   tag: "2.1"
-  pullPolicy: Always

--- a/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
@@ -1,12 +1,3 @@
-replicaCount: 1
-image:
-  repository: ghcr.io/wbstack/queryservice-updater
-  pullPolicy: Always
-app:
-  sleepTime: 5
-  loopLimit: 100
-  getBatchesEndpoint: http://api-app-backend.default.svc.cluster.local/backend/qs/getBatches
-  wikibaseScheme: http
 resources:
   requests:
     cpu: 80m

--- a/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
@@ -1,9 +1,9 @@
 image:
-  repository: ghcr.io/wbstack/queryservice
   tag: "0.3.6_0.6"
-  pullPolicy: Always
+
 app:
   heapSize: 2g
+
 resources:
   requests:
     cpu: 0.5
@@ -11,9 +11,8 @@ resources:
   limits:
     cpu: 1
     memory: "4072Mi"
+
 persistence:
-  enabled: true
   accessMode: ReadWriteOnce
   storageClass: "premium-rwo"
   size: "20Gi"
-  annotations: {}

--- a/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
@@ -1,5 +1,3 @@
-platform:
-  apiBackendHost: api-app-backend.default.svc.cluster.local
 resources:
   requests:
     cpu: 60m
@@ -7,7 +5,6 @@ resources:
   limits:
     cpu: 100m
     memory: 100Mi
+
 image:
-  repository: ghcr.io/wbstack/queryservice-gateway
   tag: "2.1"
-  pullPolicy: Always

--- a/k8s/helmfile/env/staging/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice-updater.values.yaml.gotmpl
@@ -1,12 +1,3 @@
-replicaCount: 1
-image:
-  repository: ghcr.io/wbstack/queryservice-updater
-  pullPolicy: Always
-app:
-  sleepTime: 5
-  loopLimit: 100
-  getBatchesEndpoint: http://api-app-backend.default.svc.cluster.local/backend/qs/getBatches
-  wikibaseScheme: http
 resources:
   requests:
     cpu: 80m

--- a/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
@@ -1,9 +1,9 @@
 image:
-  repository: ghcr.io/wbstack/queryservice
   tag: "0.3.6_0.6"
-  pullPolicy: Always
+
 app:
   heapSize: 1g
+
 resources:
   requests:
     cpu: 0.5
@@ -11,9 +11,8 @@ resources:
   limits:
     cpu: 1
     memory: "3072Mi"
+
 persistence:
-  enabled: true
   accessMode: ReadWriteOnce
   storageClass: "premium-rwo"
   size: "20Gi"
-  annotations: {}


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of queryservice-ui|gateway|update and uses the same common config for all environments.

This state diffs cleanly against staging and production.

For local this would contain the following change:

```diff
...
          app.kubernetes.io/instance: queryservice-updater
      spec:
        containers:
          - name: queryservice-updater
            image: "ghcr.io/wbstack/queryservice-updater:0.3.84_3.9"
-           imagePullPolicy: IfNotPresent
+           imagePullPolicy: Always
            env:
              - name: WBSTACK_LOOP_LIMIT
                value: "100"
              - name: EXTRA_JVM_OPTS
                # https://medium.com/adorsys/usecontainersupport-to-the-rescue-e77d6cfea712
...
```

which I currently assume is an unwanted inconsistency. If this is not correct, we can obviously change it back.