### PR TITLE
refactor(helm): mediawiki values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/mediawiki-137-fp.values.yaml.gotmpl
@@ -1,0 +1,22 @@
+replicaCount:
+  backend: 1
+  web: 2
+  webapi: 2
+  alpha: 1
+
+mw:
+  redis:
+    # TODO fixme, no port injected into deployment...
+    # TODO fixme, no "database" ID injected into mediawiki
+    readServer: {{ .Values.services.redis.readHost }}
+    writeServer: {{ .Values.services.redis.writeHost }}
+    password:
+    passwordSecretName: redis-password
+    passwordSecretKey: password
+  elasticsearch:
+    host: elasticsearch-master.default.svc.cluster.local
+    port: 9200
+  mailgun:
+    enabled: false
+  platform:
+    apiBackendHost: api-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/local/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-137-fp.values.yaml.gotmpl
@@ -1,38 +1,16 @@
 image:
   tag: "1.37-7.4-20230112-fp-beta-0"
 
-replicaCount:
-  backend: 1
-  web: 2
-  webapi: 2
-  alpha: 1
 mw:
   settings:
     # Enable this to increase verbosity of logging in mw pods
     # This is very useful when debugging locally but may interfere with jobs
     logToStdErr: false
-
   db:
     replica: sql-mariadb-secondary.default.svc.cluster.local
     master: sql-mariadb-primary.default.svc.cluster.local
-
-  redis:
-    # TODO fixme, no port injected into deployment...
-    # TODO fixme, no "database" ID injected into mediawiki
-    readServer: {{ .Values.services.redis.readHost }}
-    writeServer: {{ .Values.services.redis.writeHost }}
-    password:
-    passwordSecretName: redis-password
-    passwordSecretKey: password
-  elasticsearch:
-    host: elasticsearch-master.default.svc.cluster.local
-    port: 9200
   mail:
     domain: examplemaildomain.localhost
-  mailgun:
-    enabled: false
-    apikey: "this is a a fake api key"
-    endpoint: "https://api.mailgun.net"
   smtp:
     enabled: true
     host: mailhog
@@ -43,8 +21,7 @@ mw:
     sitekeySecretKey: site_key
     secretkeySecretName: recaptcha-v2-dev-secrets
     secretkeySecretKey: secret_key
-  platform:
-    apiBackendHost: api-app-backend.default.svc.cluster.local
+
 resources:
   web:
     requests:

--- a/k8s/helmfile/env/production/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-137-fp.values.yaml.gotmpl
@@ -1,33 +1,14 @@
 image:
   tag: "1.37-7.4-20230112-fp-beta-0"
 
-replicaCount:
-  backend: 1
-  web: 2
-  webapi: 2
-  alpha: 1
 mw:
   settings:
     allowedProxyCidr: "10.108.0.0/14"
   db:
     replica: sql-mariadb-secondary.default.svc.cluster.local
     master: sql-mariadb-primary.default.svc.cluster.local
-
-  redis:
-    # TODO fixme, no port injected into deployment...
-    # TODO fixme, no "database" ID injected into mediawiki
-    readServer: {{ .Values.services.redis.readHost }}
-    writeServer: {{ .Values.services.redis.writeHost }}
-    password:
-    passwordSecretName: redis-password
-    passwordSecretKey: password
-  elasticsearch:
-    host: elasticsearch-master.default.svc.cluster.local
-    port: 9200
   mail:
     domain: "wikibase.cloud"
-  mailgun:
-    enabled: false
   smtp:
     enabled: true
     smtpUserSecretName: smtp-credentials
@@ -41,8 +22,7 @@ mw:
     sitekeySecretKey: site_key
     secretkeySecretName: {{ .Values.external.recaptcha2.secretName }}
     secretkeySecretKey: secret_key
-  platform:
-    apiBackendHost: api-app-backend.default.svc.cluster.local
+
 resources:
   web:
     requests:

--- a/k8s/helmfile/env/staging/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-137-fp.values.yaml.gotmpl
@@ -1,32 +1,14 @@
 image:
   tag: "1.37-7.4-20230112-fp-beta-0"
 
-replicaCount:
-  backend: 1
-  web: 2
-  webapi: 2
-  alpha: 1
 mw:
   settings:
     allowedProxyCidr: "10.112.0.0/14"
   db:
     replica: sql-mariadb-secondary.default.svc.cluster.local
     master: sql-mariadb-primary.default.svc.cluster.local
-  redis:
-    # TODO fixme, no port injected into deployment...
-    # TODO fixme, no "database" ID injected into mediawiki
-    readServer: {{ .Values.services.redis.readHost }}
-    writeServer: {{ .Values.services.redis.writeHost }}
-    password:
-    passwordSecretName: redis-password
-    passwordSecretKey: password
-  elasticsearch:
-    host: elasticsearch-master.default.svc.cluster.local
-    port: 9200
   mail:
     domain: "wikibase.dev"
-  mailgun:
-    enabled: false
   smtp:
     enabled: true
     smtpUserSecretName: smtp-credentials
@@ -40,8 +22,7 @@ mw:
     sitekeySecretKey: site_key
     secretkeySecretName: {{ .Values.external.recaptcha2.secretName }}
     secretkeySecretKey: secret_key
-  platform:
-    apiBackendHost: api-app-backend.default.svc.cluster.local
+
 resources:
   web:
     requests:


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of mediawiki and uses the same common config for all environments.

This state diffs cleanly against staging and production.

For local this would contain the following change:

```diff
default, mediawiki-137-fp-app-alpha, Deployment (apps) has changed:
...
            - name: MW_ELASTICSEARCH_PORT
              value: "9200"
            - name: MW_MAILGUN_DISABLED
              value: "yes"
            - name: MW_MAILGUN_API_KEY
-             value: "this is a a fake api key"
+             value: "1.234567e+06"
            - name: MW_MAILGUN_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_MAILGUN_ENDPOINT
-             value: https://api.mailgun.net
+             value: https://some.api.endpoint.example
            - name: MW_EMAIL_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_RECAPTCHA_SITEKEY
              valueFrom:
                secretKeyRef:
...
default, mediawiki-137-fp-app-api, Deployment (apps) has changed:
...
            - name: MW_ELASTICSEARCH_PORT
              value: "9200"
            - name: MW_MAILGUN_DISABLED
              value: "yes"
            - name: MW_MAILGUN_API_KEY
-             value: "this is a a fake api key"
+             value: "1.234567e+06"
            - name: MW_MAILGUN_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_MAILGUN_ENDPOINT
-             value: https://api.mailgun.net
+             value: https://some.api.endpoint.example
            - name: MW_EMAIL_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_RECAPTCHA_SITEKEY
              valueFrom:
                secretKeyRef:
...
...
            - name: MW_ELASTICSEARCH_PORT
              value: "9200"
            - name: MW_MAILGUN_DISABLED
              value: "yes"
            - name: MW_MAILGUN_API_KEY
-             value: "this is a a fake api key"
+             value: "1.234567e+06"
            - name: MW_MAILGUN_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_MAILGUN_ENDPOINT
-             value: https://api.mailgun.net
+             value: https://some.api.endpoint.example
            - name: MW_EMAIL_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_RECAPTCHA_SITEKEY
              valueFrom:
                secretKeyRef:
...
default, mediawiki-137-fp-app-web, Deployment (apps) has changed:
...
            - name: MW_ELASTICSEARCH_PORT
              value: "9200"
            - name: MW_MAILGUN_DISABLED
              value: "yes"
            - name: MW_MAILGUN_API_KEY
-             value: "this is a a fake api key"
+             value: "1.234567e+06"
            - name: MW_MAILGUN_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_MAILGUN_ENDPOINT
-             value: https://api.mailgun.net
+             value: https://some.api.endpoint.example
            - name: MW_EMAIL_DOMAIN
              value: examplemaildomain.localhost
            - name: MW_RECAPTCHA_SITEKEY
              valueFrom:
                secretKeyRef:
...

```

which I guess is fine as mailgun is not enabled anyways?