### PR TITLE
refactor(helm): api values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/api.values.yaml.gotmpl
@@ -1,0 +1,73 @@
+replicaCount:
+  web: 1
+  backend: 1
+  scheduler: 1
+  queue: 1
+
+useProbes: true
+
+platform:
+  backendMwHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
+# This mw db connection is only used by the queue..
+queue:
+  mw:
+    db:
+      readHost: sql-mariadb-secondary.default.svc.cluster.local
+      writeHost: sql-mariadb-primary.default.svc.cluster.local
+      # database: someDbName
+      username: mediawiki-db-manager
+      passwordSecretName: sql-secrets-init-passwords
+      passwordSecretKey: SQL_INIT_PASSWORD_MW
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+  hosts:
+  {{- range .Values.services.app.ingressHosts }}
+  - host: {{ .host }}
+    paths:
+    {{- range .paths }}
+    - {{ . | quote }}
+    {{- end }}
+  {{- end }}
+
+wbstack:
+  subdomainSuffix: {{ .Values.wbstack.subdomainSuffix }}
+  uiurl: {{ .Values.wbstack.uiurl }}
+  wikiDbProvisionVersion: mw1.37-fp-wbs1
+  wikiDbUseVersion: mw1.37-fp-wbs1
+
+app:
+  name: WBaaS Wikibase Production
+  keySecretName: api-app-secrets
+  keySecretKey: api-app-key
+  url: {{ .Values.services.app.url }}
+  cacheDriver: redis
+  queueConnection: redis
+  jwtSecretSecretName: api-app-secrets
+  jwtSecretSecretKey: api-app-jwt-secret
+  queryServiceHost: queryservice.default.svc.cluster.local:9999
+  elasticSearchHost: elasticsearch-master.default.svc.cluster.local:9200
+  redis:
+    # TODO is it possible to take advantage of replicas here?
+    host: {{ .Values.services.redis.writeHost }}
+    passwordSecretName: redis-password
+    passwordSecretKey: password
+    # Default values includes a password right now, so we need to explictly set this as empty
+    password:
+    port: {{ .Values.services.redis.port }}
+    db: {{ .Values.services.redis.databases.apiDb }}
+    cachedb: {{ .Values.services.redis.databases.apiCacheDb }}
+    prefix: wikibase_production_api
+  db:
+    connection: mysql
+    readHost: sql-mariadb-secondary.default.svc.cluster.local
+    writeHost: sql-mariadb-primary.default.svc.cluster.local
+    port: 3306
+    name: {{ .Values.services.sql.api.db }}
+    user: {{ .Values.services.sql.api.user }}
+    passwordSecretName: sql-secrets-init-passwords
+    passwordSecretKey: SQL_INIT_PASSWORD_API

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,26 +1,6 @@
 image:
   tag: "8x.9.11"
 
-replicaCount:
-  web: 1
-  backend: 1
-  scheduler: 1
-  queue: 1
-
-useProbes: true
-
-platform:
-  backendMwHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-# This mw db connection is only used by the queue..
-queue:
-  mw:
-    db:
-      readHost: sql-mariadb-secondary.default.svc.cluster.local
-      writeHost: sql-mariadb-primary.default.svc.cluster.local
-      # database: someDbName
-      username: mediawiki-db-manager
-      passwordSecretName: sql-secrets-init-passwords
-      passwordSecretKey: SQL_INIT_PASSWORD_MW
 resources:
   # The backed is a platform critical element, so make sure it is allowed to be a bit silly...
   backend:
@@ -52,26 +32,7 @@ resources:
       cpu: 40m
       memory: 80Mi
 
-ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-  hosts:
-  {{- range .Values.services.app.ingressHosts }}
-  - host: {{ .host }}
-    paths:
-    {{- range .paths }}
-    - {{ . | quote }}
-    {{- end }}
-  {{- end }}
-
 wbstack:
-  subdomainSuffix: {{ .Values.wbstack.subdomainSuffix }}
-  uiurl: {{ .Values.wbstack.uiurl }}
-  wikiDbProvisionVersion: mw1.37-fp-wbs1
-  wikiDbUseVersion: mw1.37-fp-wbs1
   contact:
     mail:
       recipient: someone@wikimedia.de
@@ -79,35 +40,8 @@ wbstack:
 
 app:
   name: WBaaS Localhost
-  keySecretName: api-app-secrets
-  keySecretKey: api-app-key
-  url: {{ .Values.services.app.url }}
-  cacheDriver: redis
-  queueConnection: redis
-  jwtSecretSecretName: api-app-secrets
-  jwtSecretSecretKey: api-app-jwt-secret
-  queryServiceHost: queryservice.default.svc.cluster.local:9999
-  elasticSearchHost: elasticsearch-master.default.svc.cluster.local:9200
   redis:
-    # TODO is it possible to take advantage of replicas here?
-    host: {{ .Values.services.redis.writeHost }}
-    passwordSecretName: redis-password
-    passwordSecretKey: password
-    # Default values includes a password right now, so we need to explictly set this as empty
-    password:
-    port: {{ .Values.services.redis.port }}
-    db: {{ .Values.services.redis.databases.apiDb }}
-    cachedb: {{ .Values.services.redis.databases.apiCacheDb }}
     prefix: wikibase_dev_api
-  db:
-    connection: mysql
-    readHost: sql-mariadb-secondary.default.svc.cluster.local
-    writeHost: sql-mariadb-primary.default.svc.cluster.local
-    port: 3306
-    name: {{ .Values.services.sql.api.db }}
-    user: {{ .Values.services.sql.api.user }}
-    passwordSecretName: sql-secrets-init-passwords
-    passwordSecretKey: SQL_INIT_PASSWORD_API
   mail:
     mailer: smtp
     fromaddress: noreply-local@fake.wikibase.dev

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,26 +1,6 @@
 image:
   tag: "8x.9.11"
 
-replicaCount:
-  web: 1
-  backend: 1
-  scheduler: 1
-  queue: 1
-
-useProbes: true
-
-platform:
-  backendMwHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-# This mw db connection is only used by the queue..
-queue:
-  mw:
-    db:
-      readHost: sql-mariadb-secondary.default.svc.cluster.local
-      writeHost: sql-mariadb-primary.default.svc.cluster.local
-      # database: someDbName
-      username: mediawiki-db-manager
-      passwordSecretName: sql-secrets-init-passwords
-      passwordSecretKey: SQL_INIT_PASSWORD_MW
 resources:
   # The backed is a platform critical element, so make sure it is allowed to be a bit silly...
   backend:
@@ -53,19 +33,6 @@ resources:
       memory: 80Mi
 
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-  hosts:
-  {{- range .Values.services.app.ingressHosts }}
-  - host: {{ .host }}
-    paths:
-    {{- range .paths }}
-    - {{ . | quote }}
-    {{- end }}
-  {{- end }}
   tls:
   - hosts:
     - wikibase.cloud ## todo should be injected
@@ -74,10 +41,6 @@ ingress:
 wbstack:
   maxWikisPerUser: 6
   monitoringEmail: "wb-cloud-monitoring@wikimedia.de"
-  subdomainSuffix: {{ .Values.wbstack.subdomainSuffix }}
-  uiurl: {{ .Values.wbstack.uiurl }}
-  wikiDbProvisionVersion: mw1.37-fp-wbs1
-  wikiDbUseVersion: mw1.37-fp-wbs1
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de
@@ -85,35 +48,8 @@ wbstack:
 
 app:
   name: WBaaS Wikibase Production
-  keySecretName: api-app-secrets
-  keySecretKey: api-app-key
-  url: {{ .Values.services.app.url }}
-  cacheDriver: redis
-  queueConnection: redis
-  jwtSecretSecretName: api-app-secrets
-  jwtSecretSecretKey: api-app-jwt-secret
-  queryServiceHost: queryservice.default.svc.cluster.local:9999
-  elasticSearchHost: elasticsearch-master.default.svc.cluster.local:9200
   redis:
-    # TODO is it possible to take advantage of replicas here?
-    host: {{ .Values.services.redis.writeHost }}
-    passwordSecretName: redis-password
-    passwordSecretKey: password
-    # Default values includes a password right now, so we need to explictly set this as empty
-    password:
-    port: {{ .Values.services.redis.port }}
-    db: {{ .Values.services.redis.databases.apiDb }}
-    cachedb: {{ .Values.services.redis.databases.apiCacheDb }}
     prefix: wikibase_production_api
-  db:
-    connection: mysql
-    readHost: sql-mariadb-secondary.default.svc.cluster.local
-    writeHost: sql-mariadb-primary.default.svc.cluster.local
-    port: 3306
-    name: {{ .Values.services.sql.api.db }}
-    user: {{ .Values.services.sql.api.user }}
-    passwordSecretName: sql-secrets-init-passwords
-    passwordSecretKey: SQL_INIT_PASSWORD_API
   mail:
     mailer: {{ .Values.services.app.mailer }} # mailgun/log https://laravel.com/docs/8.x/mail
     fromaddress: noreply@wikibase.cloud

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,26 +1,6 @@
 image:
   tag: "8x.9.11"
 
-replicaCount:
-  web: 1
-  backend: 1
-  scheduler: 1
-  queue: 1
-
-useProbes: true
-
-platform:
-  backendMwHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
-# This mw db connection is only used by the queue..
-queue:
-  mw:
-    db:
-      readHost: sql-mariadb-secondary.default.svc.cluster.local
-      writeHost: sql-mariadb-primary.default.svc.cluster.local
-      # database: someDbName
-      username: mediawiki-db-manager
-      passwordSecretName: sql-secrets-init-passwords
-      passwordSecretKey: SQL_INIT_PASSWORD_MW
 resources:
   # The backed is a platform critical element, so make sure it is allowed to be a bit silly...
   backend:
@@ -53,19 +33,6 @@ resources:
       memory: 80Mi
 
 ingress:
-  enabled: true
-  annotations:
-    kubernetes.io/ingress.class: nginx
-    nginx.ingress.kubernetes.io/use-regex: "true"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-  hosts:
-  {{- range .Values.services.app.ingressHosts }}
-  - host: {{ .host }}
-    paths:
-    {{- range .paths }}
-    - {{ . | quote }}
-    {{- end }}
-  {{- end }}
   tls:
   - hosts:
     - wikibase.dev ## todo should be injected
@@ -73,10 +40,6 @@ ingress:
 
 wbstack:
   maxWikisPerUser: 6
-  subdomainSuffix: {{ .Values.wbstack.subdomainSuffix }}
-  uiurl: {{ .Values.wbstack.uiurl }}
-  wikiDbProvisionVersion: mw1.37-fp-wbs1
-  wikiDbUseVersion: mw1.37-fp-wbs1
   monitoringEmail: "wb-cloud-monitoring+staging@wikimedia.de"
   contact:
     mail:
@@ -85,35 +48,8 @@ wbstack:
 
 app:
   name: WBaaS Wikibase Dev
-  keySecretName: api-app-secrets
-  keySecretKey: api-app-key
-  url: {{ .Values.services.app.url }}
-  cacheDriver: redis
-  queueConnection: redis
-  jwtSecretSecretName: api-app-secrets
-  jwtSecretSecretKey: api-app-jwt-secret
-  queryServiceHost: queryservice.default.svc.cluster.local:9999
-  elasticSearchHost: elasticsearch-master.default.svc.cluster.local:9200
   redis:
-    # TODO is it possible to take advantage of replicas here?
-    host: {{ .Values.services.redis.writeHost }}
-    passwordSecretName: redis-password
-    passwordSecretKey: password
-    # Default values includes a password right now, so we need to explictly set this as empty
-    password:
-    port: {{ .Values.services.redis.port }}
-    db: {{ .Values.services.redis.databases.apiDb }}
-    cachedb: {{ .Values.services.redis.databases.apiCacheDb }}
     prefix: wikibase_dev_api
-  db:
-    connection: mysql
-    readHost: sql-mariadb-secondary.default.svc.cluster.local
-    writeHost: sql-mariadb-primary.default.svc.cluster.local
-    port: 3306
-    name: {{ .Values.services.sql.api.db }}
-    user: {{ .Values.services.sql.api.user }}
-    passwordSecretName: sql-secrets-init-passwords
-    passwordSecretKey: SQL_INIT_PASSWORD_API
   mail:
     mailer: {{ .Values.services.app.mailer }} # mailgun/log https://laravel.com/docs/8.x/mail
     fromaddress: noreply@wikibase.dev


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of api and uses the same common config for all environments.

This state diffs cleanly against local, staging and production.