### PR TITLE
production: Bump MediaWiki to 1.37-7.4-20230112-fp-beta-0

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-137-fp.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-137-fp.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "1.37-7.4-20220930-fp-beta-0"
+  tag: "1.37-7.4-20230112-fp-beta-0"
 
 replicaCount:
   backend: 1


### PR DESCRIPTION
Bug: [T322665](https://phabricator.wikimedia.org/T322665)