### PR TITLE
cleanup helmfile: remove yaml template for local-only deployments

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -206,11 +206,13 @@ releases:
     installed: {{ eq .Environment.Name "local" | toYaml }}
     chart: cetic/adminer
     version: v0.2.1
-    <<: *default_release
+    values:
+      - env/local/adminer-cetic.values.yaml.gotmpl
 
   - name: mailhog
     installed: {{ eq .Environment.Name "local" | toYaml }}
     namespace: default
     chart: codecentric/mailhog
     version: 5.0.1
-    <<: *default_release
+    values:
+      - env/local/mailhog.values.yaml.gotmpl


### PR DESCRIPTION
Just a small cleanup PR, I thought this might make sense, because mailhog and adminer will never-ever get deployed somewhere else than `local` and also this gets rid of the `skipping missing values file matching "env/common/..."` lines for these releases while using the Makefile.
