### PR TITLE
refactor(helm): sql values are repeated across envs

### DIFF
--- a/k8s/helmfile/env/common/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/common/sql.values.yaml.gotmpl
@@ -1,0 +1,159 @@
+architecture: replication
+
+auth:
+  forcePassword: true
+  existingSecret: sql-secrets-passwords
+
+primary:
+  persistence:
+    enabled: true
+    size: {{ .Values.services.sql.storageSize | quote }}
+  extraEnvVarsSecret: sql-secrets-init-passwords
+  configuration: |-
+    [mysqld]
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mariadb
+    plugin_dir=/opt/bitnami/mariadb/plugin
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    tmpdir=/opt/bitnami/mariadb/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+    log-error=/opt/bitnami/mariadb/logs/mysqld.log
+    character-set-server=UTF8
+    collation-server=utf8_general_ci
+
+    # Custom
+    # 16MB, default is 8MB, bitnami was 128
+    key_buffer_size=16777216
+    # 2800MB (70% of 4000), default & bitnami was 134MB (134217728)
+    innodb_buffer_pool_size=2936012800
+    # 8MB, default & bitnami was 16MB (16777216)
+    tmp_table_size=8388608
+    # 80, default & bitnami was 151
+    max_connections=80
+    # 7 days, default & bitnami is 0 (keep forever.)
+    expire_logs_days=7
+    # 100MB, default & bitnami was 1GB (1073741824)
+    max_binlog_size=107374182
+
+    [mysql]
+    # https://forums.mysql.com/read.php?103,189835,192421#msg-192421
+    default-character-set=UTF8
+
+    [client]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    plugin_dir=/opt/bitnami/mariadb/plugin
+
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+
+secondary:
+  replicaCount: 1
+  persistence:
+    enabled: true
+    size: {{ .Values.services.sql.storageSize | quote }}
+  configuration: |-
+    [mysqld]
+    skip-name-resolve
+    explicit_defaults_for_timestamp
+    basedir=/opt/bitnami/mariadb
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    tmpdir=/opt/bitnami/mariadb/tmp
+    max_allowed_packet=16M
+    bind-address=0.0.0.0
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+    log-error=/opt/bitnami/mariadb/logs/mysqld.log
+    character-set-server=UTF8
+    collation-server=utf8_general_ci
+
+    # Custom
+    # 16MB, default is 8MB, bitnami was 128
+    key_buffer_size=16777216
+    # 2800MB (70% of 4000), default & bitnami was 134MB (134217728)
+    innodb_buffer_pool_size=2936012800
+    # 8MB, default & bitnami was 16MB (16777216)
+    tmp_table_size=8388608
+    # 80, default & bitnami was 151
+    max_connections=80
+    # 7 days, default & bitnami is 0 (keep forever.)
+    expire_logs_days=7
+    # 100MB, default & bitnami was 1GB (1073741824)
+    max_binlog_size=107374182
+
+    [mysql]
+    # https://forums.mysql.com/read.php?103,189835,192421#msg-192421
+    default-character-set=UTF8
+
+    [client]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+
+    [manager]
+    port=3306
+    socket=/opt/bitnami/mariadb/tmp/mysql.sock
+    pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+
+global:
+  storageClass: {{ .Values.services.sql.storageClass | quote }}
+
+metrics:
+  enabled: false
+
+initdbScripts:
+  # https://docs.bitnami.com/kubernetes/infrastructure/mariadb/configuration/customize-new-instance/
+  init-primary-only.sh: |
+    #!/bin/sh
+    if [[ $(hostname) == *primary* ]]; then
+        echo "Primary node, executing"
+    else
+        echo "NOT Primary node, EXITING"
+        exit
+    fi
+
+    # Backup manager / wbaas-backup
+    echo "CREATE USER IF NOT EXISTS 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
+    echo "ALTER USER 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
+
+    # https://docs.pingcap.com/tidb/v4.0/mydumper-overview#required-privileges
+    echo "GRANT SELECT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT RELOAD ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT LOCK TABLES ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT REPLICATION CLIENT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT SHOW VIEW ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT SLAVE MONITOR ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+
+    # API
+    # TODO tighten up the grants for the api user
+    echo "CREATE USER IF NOT EXISTS 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
+    echo "ALTER USER 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
+    echo "CREATE DATABASE IF NOT EXISTS apidb;" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT ALL ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT GRANT OPTION ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
+
+    # Mediawiki
+    echo "CREATE USER IF NOT EXISTS 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
+    echo "ALTER USER 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
+    echo "CREATE DATABASE IF NOT EXISTS mediawiki;" >> /tmp/sql-init-cmds-001.txt
+    # Needed in order to create new DBs and users and perform updates
+    echo "GRANT ALL ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT ALL ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    # Needed in order to GRANT new users access to their own dbs
+    echo "GRANT GRANT OPTION ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    echo "GRANT GRANT OPTION ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    # Needed in order to create new users
+    echo "GRANT CREATE USER ON *.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
+    # In order to see and grant slave status access
+    echo "GRANT REPLICA MONITOR, BINLOG MONITOR ON *.* TO 'mediawiki-db-manager'@'%' WITH GRANT OPTION;" >> /tmp/sql-init-cmds-001.txt
+
+    # Flush privs
+    echo "FLUSH PRIVILEGES;" >> /tmp/sql-init-cmds-001.txt
+
+    mysql -uroot -p${MARIADB_ROOT_PASSWORD} < /tmp/sql-init-cmds-001.txt
+    rm /tmp/sql-init-cmds-001.txt

--- a/k8s/helmfile/env/local/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/sql.values.yaml.gotmpl
@@ -5,7 +5,6 @@ auth:
   existingSecret: sql-secrets-passwords
 
 primary:
-  extraEnvVarsSecret: sql-secrets-init-passwords
   resources:
     requests:
       cpu: 40m
@@ -13,9 +12,7 @@ primary:
     limits:
       cpu: 750m
       memory: 1000Mi
-  persistence:
-    enabled: true
-    size: {{ .Values.services.sql.storageSize | quote }}
+    # storage: 1Gi
   configuration: |-
     [mysqld]
     skip-name-resolve
@@ -100,10 +97,6 @@ secondary:
                 echo "More than $REPLICATION_THRESHOLD seconds behind primary"
                 exit 1;
               fi
-  persistence:
-    enabled: true
-    size: {{ .Values.services.sql.storageSize | quote }}
-
   configuration: |-
     [mysqld]
     skip-name-resolve
@@ -145,59 +138,3 @@ secondary:
     port=3306
     socket=/opt/bitnami/mariadb/tmp/mysql.sock
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-
-global:
-  storageClass: {{ .Values.services.sql.storageClass | quote }}
-metrics:
-  enabled: false
-initdbScripts:
-  # https://docs.bitnami.com/kubernetes/infrastructure/mariadb/configuration/customize-new-instance/
-  init-primary-only.sh: |
-    #!/bin/sh
-    if [[ $(hostname) == *primary* ]]; then
-        echo "Primary node, executing"
-    else
-        echo "NOT Primary node, EXITING"
-        exit
-    fi
-
-    # Backup manager / wbaas-backup
-    echo "CREATE USER IF NOT EXISTS 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
-
-    # https://docs.pingcap.com/tidb/v4.0/mydumper-overview#required-privileges
-    echo "GRANT SELECT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT RELOAD ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT LOCK TABLES ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT REPLICATION CLIENT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT SHOW VIEW ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT SLAVE MONITOR ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # API
-    # TODO tighten up the grants for the api user
-    echo "CREATE USER IF NOT EXISTS 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
-    echo "CREATE DATABASE IF NOT EXISTS apidb;" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT ALL ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT GRANT OPTION ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # Mediawiki
-    echo "CREATE USER IF NOT EXISTS 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
-    echo "CREATE DATABASE IF NOT EXISTS mediawiki;" >> /tmp/sql-init-cmds-001.txt
-    # Needed in order to create new DBs and users and perform updates
-    echo "GRANT ALL ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT ALL ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # Needed in order to GRANT new users access to their own dbs
-    echo "GRANT GRANT OPTION ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT GRANT OPTION ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # Needed in order to create new users
-    echo "GRANT CREATE USER ON *.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # In order to see and grant slave status access
-    echo "GRANT REPLICA MONITOR, BINLOG MONITOR ON *.* TO 'mediawiki-db-manager'@'%' WITH GRANT OPTION;" >> /tmp/sql-init-cmds-001.txt
-
-    # Flush privs
-    echo "FLUSH PRIVILEGES;" >> /tmp/sql-init-cmds-001.txt
-
-    mysql -uroot -p${MARIADB_ROOT_PASSWORD} < /tmp/sql-init-cmds-001.txt
-    rm /tmp/sql-init-cmds-001.txt

--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -1,9 +1,3 @@
-architecture: replication
-
-auth:
-  forcePassword: true
-  existingSecret: sql-secrets-passwords
-
 primary:
   extraEnvVarsSecret: sql-secrets-init-passwords
   resources:
@@ -116,55 +110,3 @@ secondary:
     port=3306
     socket=/opt/bitnami/mariadb/tmp/mysql.sock
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-
-global:
-  storageClass: {{ .Values.services.sql.storageClass | quote }}
-metrics:
-  enabled: false
-initdbScripts:
-  # https://docs.bitnami.com/kubernetes/infrastructure/mariadb/configuration/customize-new-instance/
-  init-primary-only.sh: |
-    #!/bin/sh
-    if [[ $(hostname) == *primary* ]]; then
-        echo "Primary node, executing"
-    else
-        echo "NOT Primary node, EXITING"
-        exit
-    fi
-
-    # https://docs.pingcap.com/tidb/v4.0/mydumper-overview#required-privileges
-    echo "GRANT SELECT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT RELOAD ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT LOCK TABLES ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT REPLICATION CLIENT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT SHOW VIEW ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT SLAVE MONITOR ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # API
-    # TODO tighten up the grants for the api user
-    echo "CREATE USER IF NOT EXISTS 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
-    echo "CREATE DATABASE IF NOT EXISTS apidb;" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT ALL ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT GRANT OPTION ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # Mediawiki
-    echo "CREATE USER IF NOT EXISTS 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
-    echo "CREATE DATABASE IF NOT EXISTS mediawiki;" >> /tmp/sql-init-cmds-001.txt
-    # Needed in order to create new DBs and users and perform updates
-    echo "GRANT ALL ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT ALL ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # Needed in order to GRANT new users access to their own dbs
-    echo "GRANT GRANT OPTION ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT GRANT OPTION ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # Needed in order to create new users
-    echo "GRANT CREATE USER ON *.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # In order to see and grant slave status access
-    echo "GRANT REPLICA MONITOR, BINLOG MONITOR ON *.* TO 'mediawiki-db-manager'@'%' WITH GRANT OPTION;" >> /tmp/sql-init-cmds-001.txt
-
-    # Flush privs
-    echo "FLUSH PRIVILEGES;" >> /tmp/sql-init-cmds-001.txt
-
-    mysql -uroot -p${MARIADB_ROOT_PASSWORD} < /tmp/sql-init-cmds-001.txt
-    rm /tmp/sql-init-cmds-001.txt

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -1,11 +1,4 @@
-architecture: replication
-
-auth:
-  forcePassword: true
-  existingSecret: sql-secrets-passwords
-
 primary:
-  extraEnvVarsSecret: sql-secrets-init-passwords
   resources:
     requests:
       cpu: 40m
@@ -13,9 +6,6 @@ primary:
     limits:
       cpu: 750m
       memory: 1000Mi
-  persistence:
-    enabled: true
-    size: {{ .Values.services.sql.storageSize | quote }}
   configuration: |-
     [mysqld]
     skip-name-resolve
@@ -61,7 +51,6 @@ primary:
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 secondary:
-  replicaCount: 1
   resources:
     requests:
       cpu: 100m
@@ -100,10 +89,6 @@ secondary:
                 echo "More than $REPLICATION_THRESHOLD seconds behind primary"
                 exit 1;
               fi
-  persistence:
-    enabled: true
-    size: {{ .Values.services.sql.storageSize | quote }}
-
   configuration: |-
     [mysqld]
     skip-name-resolve
@@ -145,64 +130,3 @@ secondary:
     port=3306
     socket=/opt/bitnami/mariadb/tmp/mysql.sock
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
-
-global:
-  storageClass: {{ .Values.services.sql.storageClass | quote }}
-metrics:
-  enabled: false
-initdbScripts:
-  # https://docs.bitnami.com/kubernetes/infrastructure/mariadb/configuration/customize-new-instance/
-  init-primary-only.sh: |
-    #!/bin/sh
-    if [[ $(hostname) == *primary* ]]; then
-        echo "Primary node, executing"
-    else
-        echo "NOT Primary node, EXITING"
-        exit
-    fi
-
-    # Backup manager / wbaas-backup
-    echo "CREATE USER IF NOT EXISTS 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
-
-    # https://docs.pingcap.com/tidb/v4.0/mydumper-overview#required-privileges
-    echo "GRANT SELECT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT RELOAD ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT LOCK TABLES ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT REPLICATION CLIENT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT SHOW VIEW ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT SLAVE MONITOR ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # API
-    # TODO tighten up the grants for the api user
-    echo "CREATE USER IF NOT EXISTS 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'apiuser'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_API}';" >> /tmp/sql-init-cmds-001.txt
-    echo "CREATE DATABASE IF NOT EXISTS apidb;" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT ALL ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT GRANT OPTION ON apidb.* TO 'apiuser'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-
-    # Mediawiki
-    echo "CREATE USER IF NOT EXISTS 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
-    echo "ALTER USER 'mediawiki-db-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_MW}';" >> /tmp/sql-init-cmds-001.txt
-    echo "CREATE DATABASE IF NOT EXISTS mediawiki;" >> /tmp/sql-init-cmds-001.txt
-
-    # Needed in order to create new DBs and users and perform updates
-    echo "GRANT ALL ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT ALL ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # Needed in order to GRANT new users access to their own dbs
-    echo "GRANT GRANT OPTION ON \`mwdb_%\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    echo "GRANT GRANT OPTION ON \`mediawiki\`.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-
-    # Needed in order to create new users
-    echo "GRANT CREATE USER ON *.* TO 'mediawiki-db-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
-    # In order to see and grant slave status access
-    echo "GRANT REPLICA MONITOR, BINLOG MONITOR ON *.* TO 'mediawiki-db-manager'@'%' WITH GRANT OPTION;" >> /tmp/sql-init-cmds-001.txt
-
-
-    # Flush privs
-    echo "FLUSH PRIVILEGES;" >> /tmp/sql-init-cmds-001.txt
-
-    mysql -uroot -p${MARIADB_ROOT_PASSWORD} < /tmp/sql-init-cmds-001.txt
-    rm /tmp/sql-init-cmds-001.txt


### PR DESCRIPTION
Ticket [T326643](https://phabricator.wikimedia.org/T326643)

This PR removes the duplicated configuration of api and uses the same common config for all environments.

This state diffs cleanly against local and staging. In production, a missing command is added to the db's init script:

```diff
default, sql-mariadb-primary-init-scripts, ConfigMap (v1) has changed:                                                                                                                                     
...                                                                                                                                                                                                        
      helm.sh/chart: mariadb-10.5.0                                                                                                                                                                        
      app.kubernetes.io/instance: sql                                                                                                                                                                      
      app.kubernetes.io/managed-by: Helm                                                                                                                                                                   
      app.kubernetes.io/component: primary                                                                                                                                                                 
  data:                                                                                                                                                                                                    
-   init-primary-only.sh: |-                                                                                                                                                                               
+   init-primary-only.sh: |                                                                                                                                                                                
      #!/bin/sh                                                                                                                                                                                            
      if [[ $(hostname) == *primary* ]]; then                                                                                                                                                              
          echo "Primary node, executing"                                                                                                                                                                   
      else                                                                                                                                                                                                 
          echo "NOT Primary node, EXITING"
          exit
      fi
+   
+     # Backup manager / wbaas-backup
+     echo "CREATE USER IF NOT EXISTS 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
+     echo "ALTER USER 'backup-manager'@'%' IDENTIFIED BY '${SQL_INIT_PASSWORD_BACKUPS}';" >> /tmp/sql-init-cmds-001.txt
     
      # https://docs.pingcap.com/tidb/v4.0/mydumper-overview#required-privileges
      echo "GRANT SELECT ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
      echo "GRANT RELOAD ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
      echo "GRANT LOCK TABLES ON *.* TO 'backup-manager'@'%';" >> /tmp/sql-init-cmds-001.txt
...
```

Looking at the source code for the underlying image https://github.com/bitnami/containers/blob/main/bitnami/mariadb/10.9/debian-11/rootfs/opt/bitnami/scripts/libmariadb.sh#L342 this should never run though (the database is already initialized) so this is basically a no-op for bookkeeping purposes.