### PR TITLE
fix(local): elasticsearch pods need to run on the same node locally

### DIFF
--- a/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
@@ -2,6 +2,10 @@ imageTag: "6.8.23-wmde.6"
 
 esJavaOpts: "-Xms1g -Xmx1g"
 
+# hard affinity won't work locally as there is just a single
+# node running minikube
+antiAffinity: soft
+
 resources:
   requests:
     cpu: "500m"

--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -2,8 +2,6 @@ imageTag: "6.8.23-wmde.6"
 
 esJavaOpts: "-Xms2g -Xmx2g"
 
-antiAffinity: hard
-
 resources:
   requests:
     cpu: "500m"


### PR DESCRIPTION
I noticed that applying the current state to my local cluster makes ES fail to run as the affinity rules won't work for the minikube cluster:

```
Events:
  Type     Reason            Age                 From               Message
  ----     ------            ----                ----               -------
  Warning  FailedScheduling  118s                default-scheduler  0/1 nodes are available: 1 node(s) didn't match pod anti-affinity rules.
  Warning  FailedScheduling  34s (x1 over 103s)  default-scheduler  0/1 nodes are available: 1 node(s) didn't match pod anti-affinity rules.
```

This PR makes local env use `soft` affinity instead.