### PR TITLE
fix(jobs): mw jobs script references inexistent json file

### DIFF
--- a/k8s/jobs/runAllMWJobs.sh
+++ b/k8s/jobs/runAllMWJobs.sh
@@ -3,7 +3,7 @@ MW_POD_JSON=$(kubectl get pods $MW_POD -o=json)
 echo ${MW_POD_JSON} > mw_pod.json
 
 kubectl create -f runAllMWJobsJob.yaml -o=json --dry-run=client |\
-jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - mw_pod.json queryservice_pod.json |\
+jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - mw_pod.json |\
 jq ".[0].spec.template.spec.containers[0].env = .[1].spec.containers[0].env" |\
 jq ".[0]" |\
 jq ".spec.template.spec.containers[0].env += [{\"name\": \"WBS_DOMAIN\", \"value\": \"${WBS_DOMAIN}\"}]" |\


### PR DESCRIPTION
Running `WBS_DOMAIN=foo.wbaas.localhost ./loadElasticsearchAndRunMWJobs.sh` currently prints an error about a file that is never referenced and/or created anywhere else:

```
jq: error: Could not open file queryservice_pod.json: No such file or directory
```