### PR TITLE
chore(es-staging): revert non-working logging changes

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -28,6 +28,3 @@ esConfig:
     # this is supposed to speed up node recovery
     # the value of 20 is just a guess right now
     cluster.routing.allocation.node_initial_primaries_recoveries: 20
-
-  log4j2.properties: |
-    logger.transport.level = debug


### PR DESCRIPTION
#722 did not work at all

```
Defaulted container "elasticsearch" out of: elasticsearch, configure-sysctl (init)
Exception in thread "main" org.apache.logging.log4j.core.config.ConfigurationException: No name attribute provided for Logger transport
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder.createLogger(PropertiesConfigurationBuilder.java:256)
        at org.apache.logging.log4j.core.config.properties.PropertiesConfigurationBuilder.build(PropertiesConfigurationBuilder.java:178)
        at org.elasticsearch.common.logging.LogConfigurator$2.getConfiguration(LogConfigurator.java:214)
        at org.elasticsearch.common.logging.LogConfigurator$2.getConfiguration(LogConfigurator.java:182)
        at org.apache.logging.log4j.core.config.ConfigurationFactory.getConfiguration(ConfigurationFactory.java:302)
        at org.elasticsearch.common.logging.LogConfigurator$3.visitFile(LogConfigurator.java:222)
        at org.elasticsearch.common.logging.LogConfigurator$3.visitFile(LogConfigurator.java:218)
        at java.base/java.nio.file.Files.walkFileTree(Files.java:2804)
        at org.elasticsearch.common.logging.LogConfigurator.configure(LogConfigurator.java:218)
        at org.elasticsearch.common.logging.LogConfigurator.configure(LogConfigurator.java:127)
        at org.elasticsearch.bootstrap.Bootstrap.init(Bootstrap.java:302)
        at org.elasticsearch.bootstrap.Elasticsearch.init(Elasticsearch.java:159)
        at org.elasticsearch.bootstrap.Elasticsearch.execute(Elasticsearch.java:150)
        at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86)
        at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124)
        at org.elasticsearch.cli.Command.main(Command.java:90)
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:116)
        at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:93)
Refer to the log for complete error details.
```

Reverting all logging related changes until we figure out how to do it correctly.