### PR TITLE
chore(es-staging): try increasing memory allowed for indexing

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -12,6 +12,8 @@ resources:
 
 esConfig:
   elasticsearch.yml: |
+    indices.memory.index_buffer_size: 50%
+
     # each package from https://github.com/elastic/elasticsearch/tree/b29399e2daa56afc926d610f8e0e59274a5ed952/server/src/main/java/org/elasticsearch
     # wants to have its log level set
     logger.org.elasticsearch.discovery: DEBUG


### PR DESCRIPTION
Inspecting the logs with DEBUG level show that the current boot process hangs in this method https://github.com/elastic/elasticsearch/blob/eef62fe2b992cd7f8defb9bfeaf2b9a399a37540/server/src/main/java/org/elasticsearch/indices/IndexingMemoryController.java#L108-L146

Let's see what happens if we allow for more memory to be consumed by this operation.

---

I tried this locally where it seemed to have some positive impact.