### PR TITLE
(local/staging) enable ES for new wikis

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -7,7 +7,7 @@ ingress:
 wbstack:
   maxWikisPerUser: null
   elasticSearch:
-    enabledForNewWikis: true
+    enabledByDefault: true
   contact:
     mail:
       recipient: someone@wikimedia.de

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -6,6 +6,8 @@ ingress:
 
 wbstack:
   maxWikisPerUser: null
+  elasticSearch:
+    enabledForNewWikis: true
   contact:
     mail:
       recipient: someone@wikimedia.de

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -50,7 +50,7 @@ wbstack:
   maxWikisPerUser: 6
   monitoringEmail: "wb-cloud-monitoring@wikimedia.de"
   elasticSearch:
-    enabledForNewWikis: false
+    enabledByDefault: false
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -49,6 +49,8 @@ wbstack:
   wikiDbUseVersion: mw1.37-fp-wbs1
   maxWikisPerUser: 6
   monitoringEmail: "wb-cloud-monitoring@wikimedia.de"
+  elasticSearch:
+    enabledForNewWikis: false
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -9,6 +9,8 @@ ingress:
 
 wbstack:
   monitoringEmail: "wb-cloud-monitoring+staging@wikimedia.de"
+  elasticSearch:
+    enabledForNewWikis: true
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -10,7 +10,7 @@ ingress:
 wbstack:
   monitoringEmail: "wb-cloud-monitoring+staging@wikimedia.de"
   elasticSearch:
-    enabledForNewWikis: true
+    enabledByDefault: true
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -129,7 +129,7 @@ releases:
 
   - name: api
     chart: wbstack/api
-    version: 0.20.1
+    version: 0.20.2
     namespace: default
     <<: *default_release
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T329551

> :warning: depends on https://github.com/wbstack/charts/pull/111

This PR uses api chart v0.20.2, which introduces the option to set the `WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT` env var via the charts values.

The option gets enabled for local and staging, but not production (although the new chart is used everywhere)
