### PR TITLE
(prod) Enable ES for new wikis

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -49,6 +49,8 @@ wbstack:
   wikiDbUseVersion: mw1.37-fp-wbs1
   maxWikisPerUser: 6
   monitoringEmail: "wb-cloud-monitoring@wikimedia.de"
+  elasticSearch:
+    enabledForNewWikis: true
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -50,7 +50,7 @@ wbstack:
   maxWikisPerUser: 6
   monitoringEmail: "wb-cloud-monitoring@wikimedia.de"
   elasticSearch:
-    enabledForNewWikis: true
+    enabledByDefault: true
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de


### PR DESCRIPTION
https://phabricator.wikimedia.org/T329551

> :warning: depends on https://github.com/wmde/wbaas-deploy/pull/735

Enables ES for new wikis on production
