### PR TITLE
tf: staging: enable managed prometheus

### DIFF
--- a/tf/env/staging/cluster.tf
+++ b/tf/env/staging/cluster.tf
@@ -2,6 +2,12 @@ resource "google_container_cluster" "wbaas-2" {
   name = "wbaas-2"
   remove_default_node_pool = true
   initial_node_count       = 1
+  monitoring_config {
+    enable_components = [ "SYSTEM_COMPONENTS" ]
+    managed_prometheus {
+        enabled = true
+    }
+  }
 }
 
 resource "google_container_node_pool" "wbaas-2_large" {


### PR DESCRIPTION
SYSTEM_COMPONENTS appears to be the only current
value of `enable_components` in the `monitoring_config` block. However this is not a default of the provider and it is a required field so we add it here to ensure that no change is made to it