### PR TITLE
feat(monitoring): add service monitor for ingress-nginx controller in local and staging

### DIFF
--- a/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
@@ -1,1 +1,3 @@
-# local uses production configuration so this is an empty file
+controller:
+  metrics:
+    enabled: true

--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -15,5 +15,11 @@ controller:
       $status $body_bytes_sent "$http_referer" "$http_user_agent"
       $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr
       $upstream_response_length $upstream_response_time $upstream_status $req_id
+  metrics:
+    enabled: false
+    serviceMonitor:
+      enabled: true
+      additionalLabels:
+        release: kube-prometheus-stack
 defaultBackend:
   enabled: true

--- a/k8s/helmfile/env/staging/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/ingress-nginx.values.yaml.gotmpl
@@ -1,1 +1,3 @@
-# staging uses production configuration so this is an empty file
+controller:
+  metrics:
+    enabled: true


### PR DESCRIPTION
The `ingress-nginx` controller lets us create a ServiceMonitor object for it, so we can try enabling it and see if there is helpful data to be returned.