### PR TITLE
chore(monitoring): stop scraping k8s components

### DIFF
--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -8,15 +8,30 @@ prometheus:
 alertmanager:
   enabled: false
 
-nodeExporter:
-  enabled: false
-
-kubeStateMetrics:
-  enabled: false
-
 grafana:
   enabled: false
 
-# turning this off as it introduces no-op changes on every apply
+# turning off all k8s component scraping as we are not
+# interested right now
 kubeScheduler:
+  enabled: false
+kubeApiServer:
+  enabled: false
+kubelet:
+  enabled: false
+kubeControllerManager:
+  enabled: false
+coreDns:
+  enabled: false
+kubeDns:
+  enabled: false
+kubeEtcd:
+  enabled: false
+kubeProxy:
+  enabled: false
+kubeStateMetrics:
+  enabled: false
+nodeExporter:
+  enabled: false
+kubeStateMetrics:
   enabled: false


### PR DESCRIPTION
The default scraping of all k8s components is currently creating ~500 samples per second noone of us will ever have a look at (or not yet). For now, we can disable these and try to get the metrics we are interested in first.