### PR TITLE
fix(monitoring): ingress-nginx servicemonitor should be located in monitoring namespace

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -18,6 +18,7 @@ controller:
   metrics:
     enabled: false
     serviceMonitor:
+      namespace: monitoring
       enabled: true
       additionalLabels:
         release: kube-prometheus-stack


### PR DESCRIPTION
#744 implicitly put the `ServiceMonitor` into the `kube-system` namespace while all other monitors are in `monitoring`.