### PR TITLE
feat(monitoring): enable ingress-nginx metrics in production

### DIFF
--- a/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
@@ -1,3 +1,1 @@
-controller:
-  metrics:
-    enabled: true
+# local matches production

--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -16,7 +16,7 @@ controller:
       $request_length $request_time [$proxy_upstream_name] [$proxy_alternative_upstream_name] $upstream_addr
       $upstream_response_length $upstream_response_time $upstream_status $req_id
   metrics:
-    enabled: false
+    enabled: true
     serviceMonitor:
       namespace: monitoring
       enabled: true

--- a/k8s/helmfile/env/staging/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/ingress-nginx.values.yaml.gotmpl
@@ -1,3 +1,1 @@
-controller:
-  metrics:
-    enabled: true
+# staging matches production


### PR DESCRIPTION
Production equivalent of #744 

Depends on #749 