### PR TITLE
fix(staging): es exporter label collides with gke provided ones

### DIFF
--- a/k8s/helmfile/env/local/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,1 +1,6 @@
-# local re-uses production configuration
+serviceMonitor:
+  metricRelabelings:
+    - sourceLabels: [cluster]
+      targetLabel: es_cluster
+    - regex: ^cluster$
+      action: labeldrop

--- a/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,1 +1,6 @@
-# staging re-uses production configuration
+serviceMonitor:
+  metricRelabelings:
+    - sourceLabels: [cluster]
+      targetLabel: es_cluster
+    - regex: ^cluster$
+      action: labeldrop


### PR DESCRIPTION
Looking at the recently introduced ES metrics in GCP, it occured to me there is no way to distinguish the data coming from staging and production environments. This seems to be due to the fact that GKE would like to use a  `cluster` label for providing that information (it does so for the nginx metrics), but fails to do so for ES as the ES exporter already uses this label to provide the ES cluster's name.

This PR tries to fix the situation by relabeling the `cluster` value that is provided to `es_cluster`.

This is tested locally where it worked for me. The PR also contains the changes for staging.