### PR TITLE
fix(prod-monitoring): cluster label is overloaded for es metrics and needs renaming

### DIFF
--- a/k8s/helmfile/env/local/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,6 +1,1 @@
-serviceMonitor:
-  metricRelabelings:
-    - sourceLabels: [cluster]
-      targetLabel: es_cluster
-    - regex: ^cluster$
-      action: labeldrop
+# local uses production configuration

--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -5,3 +5,8 @@ serviceMonitor:
   enabled: true
   labels:
     release: kube-prometheus-stack
+  metricRelabelings:
+    - sourceLabels: [cluster]
+      targetLabel: es_cluster
+    - regex: ^cluster$
+      action: labeldrop

--- a/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,6 +1,1 @@
-serviceMonitor:
-  metricRelabelings:
-    - sourceLabels: [cluster]
-      targetLabel: es_cluster
-    - regex: ^cluster$
-      action: labeldrop
+# staging uses production configuration


### PR DESCRIPTION
#752 seems to have worked in staging, so let's also try production