### PR TITLE
chore(monitoring): raise es and prometheus scrape timeout

### DIFF
--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -1,5 +1,6 @@
 prometheus:
   prometheusSpec:
+    scrapeTimeout: 60s
     image:
       registry: gke.gcr.io
       repository: prometheus-engine/prometheus

--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,5 +1,6 @@
 es:
   uri: http://elasticsearch-master.default.svc.cluster.local:9200
+  timeout: 90s
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
We see a lot of exporter errors like this in production right now:

```
level=warn ts=2023-02-23T14:20:43.086498137Z caller=indices_settings.go:167 msg="failed to fetch and decode cluster settings stats" err="failed to get from http://elasticsearch-master.default.svc.cluster.local:9200/_all/_settings: Get \"http://elasticsearch-master.default.svc.cluster.local:9200/_all/_settings\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
level=warn ts=2023-02-23T14:20:53.087469215Z caller=indices_settings.go:167 msg="failed to fetch and decode cluster settings stats" err="failed to get from http://elasticsearch-master.default.svc.cluster.local:9200/_all/_settings: Get \"http://elasticsearch-master.default.svc.cluster.local:9200/_all/_settings\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
level=warn ts=2023-02-23T14:21:13.089357952Z caller=indices_settings.go:167 msg="failed to fetch and decode cluster settings stats" err="failed to get from http://elasticsearch-master.default.svc.cluster.local:9200/_all/_settings: Get \"http://elasticsearch-master.default.svc.cluster.local:9200/_all/_settings\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"
```

curl-ing the metrics endpoint confirms this is _very_ slow, so let's try raising this limit.

---

Also it seems that the default scrape timeout of 10s does not work with our production setup as response times are way slower:

```
➜  ~ curl -o /dev/null -s -w 'Total: %{time_total}s\n'  http://localhost:9108/metrics                                                                                                           production
Total: 25.828374s
➜  ~ curl -o /dev/null -s -w 'Total: %{time_total}s\n'  http://localhost:9108/metrics                                                                                                           production
Total: 30.396791s
```