### PR TITLE
fix(monitoring): scrape timeout cannot be greater than scrape interval

### DIFF
--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -1,7 +1,5 @@
 prometheus:
   prometheusSpec:
-    scrapeTimeout: 50s
-    scrapeInterval: 60s
     image:
       registry: gke.gcr.io
       repository: prometheus-engine/prometheus

--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -1,6 +1,7 @@
 prometheus:
   prometheusSpec:
-    scrapeTimeout: 60s
+    scrapeTimeout: 50s
+    scrapeInterval: 60s
     image:
       registry: gke.gcr.io
       repository: prometheus-engine/prometheus

--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -3,6 +3,8 @@ es:
   timeout: 90s
 
 serviceMonitor:
+  scrapeTimeout: 50s
+  interval: 60s
   enabled: true
   labels:
     release: kube-prometheus-stack


### PR DESCRIPTION
Applying #754 works just fine, however the created `Prometheus` resource will have a sneaky message in its metadata about how it cannot use the given configuration:

```
Message:               creating config failed: generating config failed: scrapeTimeout "60s" greater than scrapeInterval "30s"
```

This PR lowers the timeout a bit, while raising the interval, so that the change will actually take effect. Also, these limits are now also adjusted for ES. Everything else can still be monitored at the default intervals.