### PR TITLE
fix(monitoring): set resource limits for unbounded pods

### DIFF
--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -1,3 +1,12 @@
+prometheusOperator:
+  resources:
+    limits:
+      cpu: 200m
+      memory: 200Mi
+    requests:
+      cpu: 100m
+      memory: 100Mi
+
 prometheus:
   prometheusSpec:
     image:

--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -2,6 +2,14 @@ es:
   uri: http://elasticsearch-master.default.svc.cluster.local:9200
   timeout: 90s
 
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 100m
+    memory: 256Mi
+
 serviceMonitor:
   scrapeTimeout: 50s
   interval: 60s


### PR DESCRIPTION
The Prometheus Operator as well as the ElasticSearch exporter currently run with no resource limits set. We should limit them from guarding against unwanted runaway resource usage.