### PR TITLE
fix(monitoring): es exporter crashes when running with limited resources

### DIFF
--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -4,11 +4,11 @@ es:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 250m
+    memory: 512Mi
   limits:
-    cpu: 100m
-    memory: 256Mi
+    cpu: 250m
+    memory: 512Mi
 
 serviceMonitor:
   scrapeTimeout: 50s


### PR DESCRIPTION
Since #759, the ElasticSearch exporter is stuck in CrashLoopBackoff. While the logs do not show anything suspicious, I assume this is caused by resource limits.