### PR TITLE
fix(monitoring): further raise memory limits for es exporter

### DIFF
--- a/k8s/helmfile/env/local/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,1 +1,7 @@
-# local uses production configuration
+resources:
+  requests:
+    cpu: 125m
+    memory: 156Mi
+  limits:
+    cpu: 125m
+    memory: 256Mi

--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -5,10 +5,10 @@ es:
 resources:
   requests:
     cpu: 250m
-    memory: 512Mi
+    memory: 2Gi
   limits:
     cpu: 250m
-    memory: 512Mi
+    memory: 2Gi
 
 serviceMonitor:
   scrapeTimeout: 50s

--- a/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -1,1 +1,7 @@
-# staging uses production configuration
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 250m
+    memory: 512Mi


### PR DESCRIPTION
The pod is still crashing, even with the limits from #761 