### PR TITLE
chore(monitoring): lower es exporter limits

### DIFF
--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter.values.yaml.gotmpl
@@ -5,7 +5,7 @@ es:
 resources:
   requests:
     cpu: 250m
-    memory: 2Gi
+    memory: 1.25Gi
   limits:
     cpu: 250m
     memory: 2Gi


### PR DESCRIPTION
After having a look at how this behaves in production (without crashing), it seems the RAM consumed is always slightly below 1GB, meaning we can lower the allocation a bit again.