### PR TITLE
chore(jobs): use one-off temp files for storing pod spec

### DIFF
--- a/k8s/jobs/loadElasticSearchOnly.sh
+++ b/k8s/jobs/loadElasticSearchOnly.sh
@@ -1,10 +1,12 @@
+tmp_file=$(mktemp --suffix=.json)
+
 WIKI_ID=$(kubectl exec -it deployments/api-app-backend -- sh -c "php artisan wbs-wiki:get domain $WBS_DOMAIN" | jq -r '.id' )
 API_POD=$(kubectl get pods --field-selector='status.phase=Running' -l app.kubernetes.io/name=api,app.kubernetes.io/component=app-backend -o jsonpath="{.items[0].metadata.name}")
 API_POD_JSON=$(kubectl get pods $API_POD -o=json)
-echo ${API_POD_JSON} > api_pod.json
+echo ${API_POD_JSON} > $tmp_file
 
 kubectl create -f elasticSearchImportJob.yaml -o=json --dry-run=client |\
-jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - api_pod.json |\
+jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - $tmp_file |\
 jq ".[0].spec.template.spec.containers[0].env = .[1].spec.containers[0].env" |\
 jq ".[0]" |\
 jq ".spec.template.spec.containers[0].env += [{\"name\": \"WIKI_ID\", \"value\": \"${WIKI_ID}\"}]" |\

--- a/k8s/jobs/rebuildQuantityUnitsJob.sh
+++ b/k8s/jobs/rebuildQuantityUnitsJob.sh
@@ -1,9 +1,11 @@
+tmp_file=$(mktemp --suffix=.json)
+
 MW_POD=$(kubectl get pods --field-selector='status.phase=Running' -l app.kubernetes.io/name=mediawiki,app.kubernetes.io/component=app-backend -o jsonpath="{.items[0].metadata.name}")
 MW_POD_JSON=$(kubectl get pods $MW_POD -o=json)
-echo ${MW_POD_JSON} > mw_pod.json
+echo ${MW_POD_JSON} > $tmp_file
 
 kubectl create -f rebuildQuantityUnitsJob.yaml -o=json --dry-run=client |\
-jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - mw_pod.json |\
+jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - $tmp_file |\
 jq ".[0].spec.template.spec.containers[0].env = .[1].spec.containers[0].env" |\
 jq ".[0]" |\
 jq ".spec.template.spec.containers[0].env += [{\"name\": \"WBS_DOMAIN\", \"value\": \"${WBS_DOMAIN}\"}]" |\

--- a/k8s/jobs/runAllMWJobs.sh
+++ b/k8s/jobs/runAllMWJobs.sh
@@ -1,9 +1,11 @@
+tmp_file=$(mktemp --suffix=.json)
+
 MW_POD=$(kubectl get pods --field-selector='status.phase=Running' -l app.kubernetes.io/name=mediawiki,app.kubernetes.io/component=app-backend -o jsonpath="{.items[0].metadata.name}")
 MW_POD_JSON=$(kubectl get pods $MW_POD -o=json)
-echo ${MW_POD_JSON} > mw_pod.json
+echo ${MW_POD_JSON} > $tmp_file
 
 kubectl create -f runAllMWJobsJob.yaml -o=json --dry-run=client |\
-jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - mw_pod.json |\
+jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - $tmp_file |\
 jq ".[0].spec.template.spec.containers[0].env = .[1].spec.containers[0].env" |\
 jq ".[0]" |\
 jq ".spec.template.spec.containers[0].env += [{\"name\": \"WBS_DOMAIN\", \"value\": \"${WBS_DOMAIN}\"}]" |\


### PR DESCRIPTION
I keep checking these in to source control, and this might be the cheapest way to keep me from doing so.