### PR TITLE
chore(local): prometheus defaults exceed available resources

### DIFF
--- a/k8s/helmfile/env/local/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/kube-prometheus-stack.values.yaml.gotmpl
@@ -21,6 +21,13 @@ grafana:
 
 prometheus:
   prometheusSpec:
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "0.1Gi"
+      limits:
+        cpu: "100m"
+        memory: "0.1Gi"
     image:
       registry: quay.io
       repository: prometheus/prometheus


### PR DESCRIPTION
Sometimes, I still have the prometheus-operator failing to create the prometheus pods in local development. There is no real indication as of why, but lowering resource limits seems to help getting it up and running consistently.