### PR TITLE
chore(ci): checkout v2 uses deprecated node version

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-
-      - name: yamllint
+      - name: Check out repository
+        uses: actions/checkout@v3
+      - name: Lint YAML files
         uses: ibiqlik/action-yamllint@v3


### PR DESCRIPTION
Running the `test` action in this repository currently results in a warning:

![image](https://user-images.githubusercontent.com/1662740/222437942-934a7614-9a68-44b8-adb5-58d4b8a1776b.png)

Instead of changing the default node version in the v2 checkout action, we can also just upgrade to v3.