### PR TITLE
chore(monitoring): stats-cron has been superseded

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -200,6 +200,7 @@ releases:
 
   - name: stats-cron
     namespace: default
+    installed: false
     chart: ./../../charts/stats-cron
     <<: *default_release
 


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T331270

Before actually removing code and configuration, we'll need to "uninstall" the release.