### PR TITLE
feat(monitoring): collect service metrics for ui

### DIFF
--- a/k8s/helmfile/env/production/ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ui.values.yaml.gotmpl
@@ -31,3 +31,6 @@ ui:
   configMapName: wbaas-ui-config
   recaptchaSitekeySecretName: {{ .Values.external.recaptcha3.secretName }}
   recaptchaSitekeySecretKey: site_key
+
+podLabels:
+  sidecar.istio.io/inject: "true"

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -146,7 +146,7 @@ releases:
   - name: ui
     namespace: default
     chart: wbstack/ui
-    version: 0.3.0
+    version: 0.3.1
     <<: *default_release
 
   - name: mediawiki-137-fp


### PR DESCRIPTION
Requires #779 and https://github.com/wbstack/charts/pull/112

UI can serve as a better canary than ElasticSearch itself, allowing us to roll back changes more easily in case something unexpected goes wrong.