### PR TITLE
(makefile) Add `helmfile-sync`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,11 @@ helmfile-deps:
 # local environment is used (as one is needed), and any will do
 	cd ./k8s/helmfile && helmfile --environment local deps
 
+.PHONY: helmfile-sync
+helmfile-sync: # @HELP Sync all resources defined in the Helmfile. This can help if an initial apply-local didn't complete.
+helmfile-sync:
+	cd ./k8s/helmfile && helmfile --environment local sync
+
 PHONY: init-%
 init-local: # @HELP Initialize terraform state for your local setup. This does not create any resources. It also downloads any new modules
 init-staging: # @HELP Initialize terraform state for staging. This does not create any resources. It also downloads any new modules

--- a/doc/local-dev-env.md
+++ b/doc/local-dev-env.md
@@ -272,3 +272,6 @@ Here are a few things to try:
   - make sure the minikube tunnel is running `make minikube-tunnel`
   - make sure you are using http:// and not https:// (there are no TLS certificates)
   - check the health of your pods `kubectl --profile minikube-wbaas get pods`
+
+### **API isn't running // Some pods are missing**
+While running an initial `helmfile apply` for setting up all the k8s resources, it can happen that it doesn't complete all deployments, but helm thinks it did. To make sure everything that should be deployed was actually deployed, you can run `make helmfile-sync`.


### PR DESCRIPTION
Adds `helmfile-sync` make target and some documentation.

Sometimes an initial `make apply-local` times out (or something) and helm seems to be confused on what is actually deployed and what is not. An usual symptom of this is that the API pods aren't deployed.