### PR TITLE
chore(elasticsearch): try raising limit for fetch_shard_store threadpool in staging

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -16,3 +16,19 @@ volumeClaimTemplate:
   resources:
     requests:
       storage: 10.1Gi
+
+esConfig:
+  elasticsearch.yml: |
+    # T309396
+    xpack.ml.enabled: false
+    xpack.monitoring.collection.enabled: false
+    xpack.watcher.enabled: false
+    xpack.security.enabled: false
+    xpack.graph.enabled: false
+    xpack.logstash.enabled: false
+    xpack.ccr.enabled: false
+
+    # T309378
+    action.auto_create_index: false
+
+    thread_pool.fetch_shard_store.max: 100


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T328740

It seems the `fetch_shard_store` thread pools max out their limit (currently 20 in production) when a sibling node is currently booting / recovering. Let's see if raising this limit can help us make the startup procedure a bit faster.