### PR TITLE
WIP - Add script for getting a list of ordered wiki domains by activity

### DIFF
--- a/bin/get-wiki-domains-ordered-by-active-users
+++ b/bin/get-wiki-domains-ordered-by-active-users
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euo pipefail
+
+WIKIS=$(kubectl exec -ti sql-mariadb-secondary-0 -- bash -c 'echo "use apidb; SELECT * FROM wiki_dbs LEFT JOIN wiki_domains ON wiki_domains.wiki_id = wiki_dbs.wiki_id;" | mysql -N -u root -p${MARIADB_MASTER_ROOT_PASSWORD}')
+DOMAINS=""
+QUERY=""
+
+while IFS= read -r line; do
+    DB_NAME=$(echo "$line" | awk -F'\t' 'BEGIN {OFS = FS} {print $2}')
+    DB_PREFIX=$(echo "$line" | awk -F'\t' 'BEGIN {OFS = FS} {print $3}')
+    DOMAIN=$(echo "$line" | awk -F'\t' 'BEGIN {OFS = FS} {print $11}')
+
+    if [[ "$DOMAIN" == "NULL" ]]; then
+        continue;
+    fi
+
+    QUERY="$QUERY SELECT * FROM ${DB_NAME}.${DB_PREFIX}_site_stats;"
+    DOMAINS="$DOMAINS $DOMAIN"
+done <<< "$WIKIS"
+
+for domain in $DOMAINS; do echo "$domain"; done
+echo
+echo "$QUERY"


### PR DESCRIPTION
I played a bit around with the idea of writing a script to get a list of wikis, ordered by the activeness of users.

Currently though this script only spits out a list of wiki domains accompanied by a SQL query for each wiki that selects everything from the [site stats table](https://www.mediawiki.org/wiki/Manual:Site_stats_table/en). fwiw the result should be in the same order as the domain output, so you could manually execute the queries and sort the output somehow to get to the result, but yeah it's not great.

I had problems piping the actual query to a `kubectl` command that executes it, so that's where I gave up.

Feel free to decline and close this PR