### PR TITLE
fix(nginx): 138 mediawiki does not use fp suffix anymore

### DIFF
--- a/k8s/helmfile/env/staging/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/staging/platform-nginx.nginx.conf
@@ -7,7 +7,7 @@ map_hash_bucket_size 128;
 #WHERE deleted_at IS NULL
 #LIMIT 900
 map $host $mwversion {
-        default "138-fp-app";
+        default "138-app";
 }
 # Figure out which group of backends we might want to send the request to based on uri
 # TODO add Special:EntityData???


### PR DESCRIPTION
We stripped the `-fp` suffix from the release name for 1.38, but I forgot to account for this in #788 