### PR TITLE
chore(mediawiki): in production install mw 1.38 without any consumers

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-138.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-138.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "1.38-7.4-20230316-0"
+  tag: "1.38-7.4-20230321-0"
 
 replicaCount:
   backend: 1

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -160,7 +160,6 @@ releases:
     namespace: default
     chart: wbstack/mediawiki
     version: 0.10.6
-    installed: {{ eq .Environment.Name "staging" | toYaml }}
     <<: *default_release
 
   - name: queryservice-ui


### PR DESCRIPTION
This should be the first deployment of the production upgrade, doing nothing but creating an idling release that runs MediaWiki 1.38. Followup PRs can then start pointing other services (api / nginx) towards these services.