### PR TITLE
chore(mediawiki): uninstall mediawiki 1.37 release

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -153,7 +153,7 @@ releases:
     namespace: default
     chart: wbstack/mediawiki
     version: 0.10.6
-    installed: {{ ne .Environment.Name "staging" | toYaml }}
+    installed: false
     <<: *default_release
 
   - name: mediawiki-138


### PR DESCRIPTION
To be done once the production migration to 1.38 is finished.