### PR TITLE
Rewire OAuth services QuickStatements & Widar to talk with the mw 1.38 deployment

### DIFF
--- a/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
+  mediawikiBackendHost: mediawiki-138-app-backend.default.svc.cluster.local
 php:
   sessionSaveHandler: redis
   sessionSavePath:

--- a/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 platform:
-  mediawikiBackendHost: mediawiki-137-fp-app-backend.default.svc.cluster.local
+  mediawikiBackendHost: mediawiki-138-app-backend.default.svc.cluster.local
 
 replicaCount: 1
 


### PR DESCRIPTION
**only deploy this after each wiki was upgraded** otherwise we would need second instances of these service deployments I think.

This rewires our OAuth services QuickStatements & Widar to talk with the mw 1.38 deployment