### PR TITLE
fix(mediawiki): point oauth consumers to correct mediawiki host

### DIFF
--- a/k8s/helmfile/env/staging/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-quickstatements.values.yaml.gotmpl
@@ -1,1 +1,2 @@
-# the staging service matches production, so this file is empty
+platform:
+  mediawikiBackendHost: mediawiki-138-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/staging/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-widar.values.yaml.gotmpl
@@ -1,1 +1,2 @@
-# the staging service matches production, so this file is empty
+platform:
+  mediawikiBackendHost: mediawiki-138-app-backend.default.svc.cluster.local


### PR DESCRIPTION
Quickstatements is currently broken in staging as authentication still expects the (already removed) 1.37 deployment to present.