### PR TITLE
feat(mediawiki): deploy 1.39 release to local and staging and use for newly created wikis

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,10 +1,15 @@
 image:
-  tag: "8x.10.1"
+  tag: "8x.11.0"
 
 ingress:
   tls: null
 
+platform:
+  backendMwHost: mediawiki-139-app-backend.default.svc.cluster.local
+
 wbstack:
+  wikiDbProvisionVersion: mw1.39-wbs1
+  wikiDbUseVersion: mw1.39-wbs1
   maxWikisPerUser: null
   elasticSearch:
     enabledByDefault: true

--- a/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
@@ -1,0 +1,23 @@
+image:
+  tag: "1.39-7.4-20230328-0"
+
+mw:
+  settings:
+    # Enable this to increase verbosity of logging in mw pods
+    # This is very useful when debugging locally but may interfere with jobs
+    logToStdErr: false
+    allowedProxyCidr: null
+  mail:
+    domain: examplemaildomain.localhost
+  smtp:
+    enabled: true
+    host: mailhog
+    port: 1025
+    auth: false
+    smtpUserSecretName: null
+    smtpPasswordSecretName: null
+  recaptcha:
+    sitekeySecretName: recaptcha-v2-dev-secrets
+    sitekeySecretKey: site_key
+    secretkeySecretName: recaptcha-v2-dev-secrets
+    secretkeySecretKey: secret_key

--- a/k8s/helmfile/env/local/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/local/platform-nginx.nginx.conf
@@ -8,46 +8,6 @@ map_hash_bucket_size 128;
 #LIMIT 900
 map $host $mwversion {
         default "139-app";
-        "goathub.wikibase.dev" "138-app";
-        "deerbase.wikibase.dev" "138-app";
-        "coffeebase.wikibase.dev" "138-app";
-        "somethingwitty.wikibase.dev" "138-app";
-        "goat-136.wikibase.dev" "138-app";
-        "candy-collection.wikibase.dev" "138-app";
-        "potatobase.wikibase.dev" "138-app";
-        "potato.wikibase.dev" "138-app";
-        "asjhfkjsahdkjahs.wikibase.dev" "138-app";
-        "feddypropswiki.wikibase.dev" "138-app";
-        "addshore-alpha.wikibase.dev" "138-app";
-        "faketestdomain.hopto.org" "138-app";
-        "wikibasehost.ddns.net" "138-app";
-        "addshore-fake-cusstom-domain-wikibase.duckdns.org" "138-app";
-        "deerstack.wikibase.dev" "138-app";
-        "cacti.wikibase.dev" "138-app";
-        "rose-collection.wikibase.dev" "138-app";
-        "migratetestbase.ddns.net" "138-app";
-        "biodiversity.wikibase.dev" "138-app";
-        "toms-test-wikibase.duckdns.org" "138-app";
-        "potatowiki3.wikibase.dev" "138-app";
-        "charlie-test-1.wikibase.dev" "138-app";
-        "deerdeerdeer.wikibase.dev" "138-app";
-        "blob-wiki.wikibase.dev" "138-app";
-        "test-lm-02.wikibase.dev" "138-app";
-        "testwikibase-jan.wikibase.dev" "138-app";
-        "aflex.wikibase.dev" "138-app";
-        "bh20subset1.wikibase.dev" "138-app";
-        "biomarker.wikibase.dev" "138-app";
-        "testa.wikibase.dev" "138-app";
-        "carrotwiki.wikibase.dev" "138-app";
-        "sweetcornbase.wikibase.dev" "138-app";
-        "mywayordatway.wikibase.dev" "138-app";
-        "redbull.wikibase.dev" "138-app";
-        "asdfg.wikibase.dev" "138-app";
-        "asfasfasfasfasf.wikibase.dev" "138-app";
-        "wbdev.ledeniz.de" "138-app";
-        "dev-test-wbaas-custom-deer.duckdns.org" "138-app";
-        "andrew.wikibase.dev" "138-app";
-        "mw138test.wikibase.dev" "138-app";
 }
 # Figure out which group of backends we might want to send the request to based on uri
 # TODO add Special:EntityData???

--- a/k8s/helmfile/env/local/platform-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/platform-nginx.values.yaml.gotmpl
@@ -1,1 +1,4 @@
 replicaCount: 1
+
+serverBlock: |-
+{{ readFile "platform-nginx.nginx.conf" | indent 2 }}

--- a/k8s/helmfile/env/local/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/tool-quickstatements.values.yaml.gotmpl
@@ -1,1 +1,2 @@
-# the staging service matches production, so this file is empty
+platform:
+  mediawikiBackendHost: mediawiki-139-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/local/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/tool-widar.values.yaml.gotmpl
@@ -1,1 +1,2 @@
-# the local service matches production, so this file is empty
+platform:
+  mediawikiBackendHost: mediawiki-139-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -1,0 +1,75 @@
+image:
+  tag: "1.39-7.4-20230328-0"
+
+replicaCount:
+  backend: 1
+  web: 2
+  webapi: 2
+  alpha: 1
+
+mw:
+  redis:
+    # TODO fixme, no port injected into deployment...
+    # TODO fixme, no "database" ID injected into mediawiki
+    readServer: {{ .Values.services.redis.readHost }}
+    writeServer: {{ .Values.services.redis.writeHost }}
+    password:
+    passwordSecretName: redis-password
+    passwordSecretKey: password
+  elasticsearch:
+    host: elasticsearch-master.default.svc.cluster.local
+    port: 9200
+  mailgun:
+    enabled: false
+  platform:
+    apiBackendHost: api-app-backend.default.svc.cluster.local
+  settings:
+    allowedProxyCidr: "10.108.0.0/14"
+  db:
+    replica: sql-mariadb-secondary.default.svc.cluster.local
+    master: sql-mariadb-primary.default.svc.cluster.local
+  mail:
+    domain: "wikibase.cloud"
+  smtp:
+    enabled: true
+    smtpUserSecretName: smtp-credentials
+    smtpUserSecretKey: username
+    smtpPasswordSecretName: smtp-credentials
+    smtpPasswordSecretKey: password
+    host: smtp.eu.mailgun.org
+    port: 587
+  recaptcha:
+    sitekeySecretName: {{ .Values.external.recaptcha2.secretName }}
+    sitekeySecretKey: site_key
+    secretkeySecretName: {{ .Values.external.recaptcha2.secretName }}
+    secretkeySecretKey: secret_key
+
+resources:
+  web:
+    requests:
+      cpu: 150m
+      memory: 350Mi
+    limits:
+      cpu: 400m
+      memory: 750Mi
+  webapi:
+    requests:
+      cpu: 200m
+      memory: 250Mi
+    limits:
+      cpu: 500m
+      memory: 1200Mi
+  alpha:
+    requests:
+      cpu: 50m
+      memory: 40Mi
+    limits:
+      cpu: 500m
+      memory: 600Mi
+  backend:
+    requests:
+      cpu: 500m
+      memory: 600Mi
+    limits:
+      cpu: 1000m
+      memory: 1200Mi

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.10.1"
+  tag: "8x.11.0"
 
 ingress:
   tls:
@@ -8,11 +8,11 @@ ingress:
     secretName: wikibase-dev-tls
 
 platform:
-  backendMwHost: mediawiki-138-app-backend.default.svc.cluster.local
+  backendMwHost: mediawiki-139-app-backend.default.svc.cluster.local
 
 wbstack:
-  wikiDbProvisionVersion: mw1.38-wbs1
-  wikiDbUseVersion: mw1.38-wbs1
+  wikiDbProvisionVersion: mw1.39-wbs1
+  wikiDbUseVersion: mw1.39-wbs1
   monitoringEmail: "wb-cloud-monitoring+staging@wikimedia.de"
   elasticSearch:
     enabledByDefault: true

--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -1,0 +1,8 @@
+image:
+  tag: "1.39-7.4-20230328-0"
+
+mw:
+  settings:
+    allowedProxyCidr: "10.112.0.0/14"
+  mail:
+    domain: "wikibase.dev"

--- a/k8s/helmfile/env/staging/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-quickstatements.values.yaml.gotmpl
@@ -1,2 +1,2 @@
 platform:
-  mediawikiBackendHost: mediawiki-138-app-backend.default.svc.cluster.local
+  mediawikiBackendHost: mediawiki-139-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/staging/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/tool-widar.values.yaml.gotmpl
@@ -1,2 +1,2 @@
 platform:
-  mediawikiBackendHost: mediawiki-138-app-backend.default.svc.cluster.local
+  mediawikiBackendHost: mediawiki-139-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -155,6 +155,13 @@ releases:
     version: 0.10.6
     <<: *default_release
 
+  - name: mediawiki-139
+    namespace: default
+    chart: wbstack/mediawiki
+    version: 0.10.6
+    installed: {{ ne .Environment.Name "production" | toYaml }}
+    <<: *default_release
+
   - name: queryservice-ui
     namespace: default
     chart: wbstack/queryservice-ui


### PR DESCRIPTION
For staging and local, this PR:
- adds a 1.39 MediaWiki release in parallel to 1.38
- updates api to use 1.39 schemas for newly created wikis
- points OAuth consumers to the 1.39 release

In staging only:
- map all existing wikis to 1.38 for now, so that they can be migrated in a later step