### PR TITLE
chore(mediawiki): point staging canary to 139 mediawiki

### DIFF
--- a/k8s/helmfile/env/staging/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/staging/platform-nginx.nginx.conf
@@ -10,7 +10,6 @@ map $host $mwversion {
         default "139-app";
         "goathub.wikibase.dev" "138-app";
         "deerbase.wikibase.dev" "138-app";
-        "coffeebase.wikibase.dev" "138-app";
         "somethingwitty.wikibase.dev" "138-app";
         "goat-136.wikibase.dev" "138-app";
         "candy-collection.wikibase.dev" "138-app";


### PR DESCRIPTION
Trying to migrate a single wiki first.

Before deploying this, `update.php` will need to be run for the instance.