### PR TITLE
k8s: remove istio from elasticsearch

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 labels:
-  sidecar.istio.io/inject: "true"
+  sidecar.istio.io/inject: "false"
 
 image: "wikibase/elasticsearch"
 imagePullPolicy: Always


### PR DESCRIPTION
In order to test the hypothesis that istio
is causing some errors in pinging between pods
lets try removing it in production and staging