### PR TITLE
chore(elasticsearch): in staging, enable istio while excluding cluster transport from being proxied

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,3 +1,8 @@
+labels:
+  sidecar.istio.io/inject: "true"
+  traffic.sidecar.istio.io/excludeInboundPorts: "9300"
+  traffic.sidecar.istio.io/excludeOutboundPorts: "9300"
+
 imageTag: "6.8.23-wmde.6"
 
 esJavaOpts: "-Xms2g -Xmx2g"


### PR DESCRIPTION
This should allow us to find out whether Istio / Envoy do indeed interfere with intra-ES-cluster traffic or if this is a red herring.

Ideally, after deploying, no messages like this would be logged anymore:

```
[2023-03-27T16:52:50,521][WARN ][o.e.d.z.ZenDiscovery     ] [elasticsearch-master-2] master left (reason = failed to ping, tried [3] times, each with  maximum [30s] timeout), current nodes: nodes: 
```