### PR TITLE
chore(elasticsearch): in staging, try proxying elasticsearch transport ports

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,7 +1,5 @@
 labels:
   sidecar.istio.io/inject: "true"
-  traffic.sidecar.istio.io/excludeInboundPorts: "9300"
-  traffic.sidecar.istio.io/excludeOutboundPorts: "9300"
 
 imageTag: "6.8.23-wmde.6"
 


### PR DESCRIPTION
In case #824 has no effect on the number of "ping"s failing, we should try deploying this in order to find out whether istio sidecars are a part in the equation that describes slow ES startup.