### PR TITLE
fix(elasticsearch): port exclusion rules need to be given in annotation

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,5 +1,7 @@
 labels:
   sidecar.istio.io/inject: "true"
+
+podAnnotations:
   traffic.sidecar.istio.io/excludeInboundPorts: "9300"
   traffic.sidecar.istio.io/excludeOutboundPorts: "9300"
 


### PR DESCRIPTION
This was missed in #824 

See: https://istio.io/latest/docs/reference/config/annotations/