### PR TITLE
fix(elasticsearch): try "include" annotation rule for inbound es traffic

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -2,8 +2,7 @@ labels:
   sidecar.istio.io/inject: "true"
 
 podAnnotations:
-  traffic.sidecar.istio.io/excludeInboundPorts: "9300"
-  traffic.sidecar.istio.io/excludeOutboundPorts: "9300"
+  traffic.sidecar.istio.io/includeInboundPorts: "9200"
 
 imageTag: "6.8.23-wmde.6"
 


### PR DESCRIPTION
#830 seems to have broken networking entirely as nodes using that configuration are stuck in a loop of:

```
[2023-04-03T08:59:57,784][INFO ][o.e.d.z.ZenDiscovery     ] [elasticsearch-master-2] failed to send join request to master [{elasticsearch-master-1}{VtC1F-NsQvGqWaeuOXj9WA}{aqmhXCrqRqyPcLWmv6tltg}{10.112.0.30}{10.112.0.30:9300}{xpack.installed=true}], reason [RemoteTransportException[[elasticsearch-master-1][10.112.0.30:9300][internal:discovery/zen/join]]; nested: ConnectTransportException[[elasticsearch-master-2][10.112.1.40:9300] general node connection failure]; nested: TransportException[handshake failed because connection reset]; ]
```

It's not entirely clear how the precendence of the options in https://istio.io/latest/docs/reference/config/annotations/ works, but trying to allow-list inbound traffic on port 9200 seems like a good thing to try.