### PR TITLE
fix(elasticsearch): try "include" annotation rule for outbound es traffic

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -3,6 +3,7 @@ labels:
 
 podAnnotations:
   traffic.sidecar.istio.io/includeInboundPorts: "9200"
+  traffic.sidecar.istio.io/includeOutboundPorts: "9200"
 
 imageTag: "6.8.23-wmde.6"
 


### PR DESCRIPTION
Connectivity issues persist after #831, so let's try adding outbound traffic as well.