### PR TITLE
chore(elasticsearch): disable istio for staging es

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 labels:
-  sidecar.istio.io/inject: "true"
+  sidecar.istio.io/inject: "false"
 
 podAnnotations:
   traffic.sidecar.istio.io/includeInboundPorts: "*"


### PR DESCRIPTION
Disable istio for staging ES for now to free us from the logspam.