### PR TITLE
Hard disable Istio mTLS in staging

### DIFF
--- a/charts/istio-service-mesh/templates/peer-authentication.yaml
+++ b/charts/istio-service-mesh/templates/peer-authentication.yaml
@@ -1,10 +1,8 @@
 {{ if .Values.peerAuthentication.enabled }}
+{{- range .Values.peerAuthentication.objects }}
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
-metadata:
-  name: default
-  namespace: istio-system
-spec:
-  mtls:
-    mode: {{ .Values.peerAuthentication.mtls.mode }}
+{{- toYaml . | nindent 0 }}
+---
+{{- end }}
 {{ end }}

--- a/charts/istio-service-mesh/templates/peer-authentication.yaml
+++ b/charts/istio-service-mesh/templates/peer-authentication.yaml
@@ -1,0 +1,8 @@
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  mtls:
+    mode: {{ .Values.mtls.mode }}

--- a/charts/istio-service-mesh/templates/peer-authentication.yaml
+++ b/charts/istio-service-mesh/templates/peer-authentication.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.peerAuthentication.enabled }}
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
@@ -5,4 +6,5 @@ metadata:
   namespace: istio-system
 spec:
   mtls:
-    mode: {{ .Values.mtls.mode }}
+    mode: {{ .Values.peerAuthentication.mtls.mode }}
+{{ end }}

--- a/charts/istio-service-mesh/values.yaml
+++ b/charts/istio-service-mesh/values.yaml
@@ -13,3 +13,6 @@ serviceMonitor:
   interval: 15s
   additionalLabels:
     release: istio
+
+mtls:
+  mode: PERMISSIVE

--- a/charts/istio-service-mesh/values.yaml
+++ b/charts/istio-service-mesh/values.yaml
@@ -14,5 +14,7 @@ serviceMonitor:
   additionalLabels:
     release: istio
 
-mtls:
-  mode: PERMISSIVE
+peerAuthentication:
+  enabled: false
+  mtls:
+    mode: PERMISSIVE

--- a/charts/istio-service-mesh/values.yaml
+++ b/charts/istio-service-mesh/values.yaml
@@ -16,5 +16,4 @@ serviceMonitor:
 
 peerAuthentication:
   enabled: false
-  mtls:
-    mode: PERMISSIVE
+  objects: []

--- a/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/elasticsearch.values.yaml.gotmpl
@@ -2,6 +2,13 @@ imageTag: "6.8.23-wmde.6"
 
 esJavaOpts: "-Xms1g -Xmx1g"
 
+labels:
+  sidecar.istio.io/inject: "true"
+
+podAnnotations:
+  traffic.sidecar.istio.io/includeInboundPorts: "*"
+  traffic.sidecar.istio.io/excludeOutboundPorts: "9300"
+  traffic.sidecar.istio.io/excludeInboundPorts: "9300"
 # hard affinity won't work locally as there is just a single
 # node running minikube
 antiAffinity: soft

--- a/k8s/helmfile/env/local/istio-service-mesh.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/istio-service-mesh.values.yaml.gotmpl
@@ -1,3 +1,6 @@
+mtls:
+  mode: DISABLE
+
 podMonitor:
   namespace: monitoring
 

--- a/k8s/helmfile/env/local/istio-service-mesh.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/istio-service-mesh.values.yaml.gotmpl
@@ -1,5 +1,7 @@
-mtls:
-  mode: DISABLE
+peerAuthentication:
+  enabled: true
+  mtls:
+    mode: DISABLE
 
 podMonitor:
   namespace: monitoring

--- a/k8s/helmfile/env/local/istio-service-mesh.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/istio-service-mesh.values.yaml.gotmpl
@@ -1,7 +1,12 @@
 peerAuthentication:
   enabled: true
-  mtls:
-    mode: DISABLE
+  objects:
+    - metadata:
+        name: disable-mtls
+        namespace: default
+      spec:
+        mtls:
+          mode: DISABLE
 
 podMonitor:
   namespace: monitoring

--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 labels:
-  sidecar.istio.io/inject: "false"
+  sidecar.istio.io/inject: "true"
 
 podAnnotations:
   traffic.sidecar.istio.io/includeInboundPorts: "*"

--- a/k8s/helmfile/env/staging/istio-service-mesh.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/istio-service-mesh.values.yaml.gotmpl
@@ -1,4 +1,9 @@
 peerAuthentication:
   enabled: true
-  mtls:
-    mode: DISABLE
+  objects:
+    - metadata:
+        name: disable-mtls
+        namespace: default
+      spec:
+        mtls:
+          mode: DISABLE

--- a/k8s/helmfile/env/staging/istio-service-mesh.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/istio-service-mesh.values.yaml.gotmpl
@@ -1,0 +1,4 @@
+peerAuthentication:
+  enabled: true
+  mtls:
+    mode: DISABLE


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T333807

The default value of `PERMISSIVE` should work as per documentation (as it allows for both encrypted as well as unencrypted traffic), however this is not what we are seeing in staging. Instead, we can try hard disabling mTLS and see if it makes a difference.