### PR TITLE
chore(elasticsearch): introduce arbitrary config change in staging to trigger rollout of updates

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch.values.yaml.gotmpl
@@ -15,7 +15,7 @@ resources:
     cpu: "500m"
     memory: "4Gi"
   limits:
-    cpu: "1950m"
+    cpu: "2000m"
     memory: "4Gi"
 
 volumeClaimTemplate:


### PR DESCRIPTION
This PR exists for the sole purpose of trying to apply a non-critical config change, and allows us to try reproducing a scenario that whirled the production cluster into a broken state last wednesday:

- deploy changes
- while the first node is booting, delete the other pods