### PR TITLE
local: update skaffold mw conf to 1.39

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ test: # @HELP Run yamllint tests against the repository
 test:
 	yamllint --no-warnings .
 
-skaffold-mediawiki-139: skaffold-mediawiki-139
-skaffold-mediawiki-139: # @HELP Deploy the local mediawiki image using skaffold
+skaffold-mediawiki-138: # @HELP Deploy the local mediawiki 1.38 image using skaffold
+skaffold-mediawiki-139: # @HELP Deploy the local mediawiki 1.39 image using skaffold
 skaffold-ui: # @HELP Deploy the local ui image using skaffold
 skaffold-api: # @HELP Deploy the api image using skaffold
 skaffold-queryservice: # @HELP  Deploy the local queryservice image using skaffold

--- a/Makefile
+++ b/Makefile
@@ -96,8 +96,8 @@ test: # @HELP Run yamllint tests against the repository
 test:
 	yamllint --no-warnings .
 
-skaffold-mediawiki: skaffold-mediawiki-138
-skaffold-mediawiki: # @HELP Deploy the local mediawiki image using skaffold
+skaffold-mediawiki-139: skaffold-mediawiki-139
+skaffold-mediawiki-139: # @HELP Deploy the local mediawiki image using skaffold
 skaffold-ui: # @HELP Deploy the local ui image using skaffold
 skaffold-api: # @HELP Deploy the api image using skaffold
 skaffold-queryservice: # @HELP  Deploy the local queryservice image using skaffold

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -54,6 +54,46 @@ profiles:
       kubeContext: minikube-wbaas
       helm:
         releases:
+          - name: mediawiki-138
+            chartPath: ./../../charts/charts/mediawiki
+            valuesFiles:
+              - ".tmp.values.mediawiki-138.yaml"
+              - NeverPull.yaml
+            artifactOverrides:
+              image: local/skaffold/wbaas/mediawiki
+            imageStrategy:
+              helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "./helmfile-values", "-e", "local", "-r", "mediawiki-138", "-n" ]
+metadata:
+  name: mediawiki-138
+
+---
+
+apiVersion: skaffold/v2beta23
+kind: Config
+profiles:
+  - name: local
+    activation:
+      - kubeContext: minikube-wbaas
+    build:
+      artifacts:
+        - image: local/skaffold/wbaas/mediawiki
+          context: ./../../mediawiki
+          docker:
+            buildArgs:
+              LOCALIZATION_CACHE_THREAD_COUNT: 4
+              LOCALIZATION_CACHE_ADDITIONAL_PARAMS: "--lang=en,sv,de"
+              INSTALL_PROFILING_DEPS: 1
+              INSTALL_XDEBUG: 1
+      local:
+        useDockerCLI: true
+    deploy:
+      kubeContext: minikube-wbaas
+      helm:
+        releases:
           - name: mediawiki-139
             chartPath: ./../../charts/charts/mediawiki
             valuesFiles:

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -54,10 +54,10 @@ profiles:
       kubeContext: minikube-wbaas
       helm:
         releases:
-          - name: mediawiki-138
+          - name: mediawiki-139
             chartPath: ./../../charts/charts/mediawiki
             valuesFiles:
-              - ".tmp.values.mediawiki-138.yaml"
+              - ".tmp.values.mediawiki-139.yaml"
               - NeverPull.yaml
             artifactOverrides:
               image: local/skaffold/wbaas/mediawiki
@@ -66,9 +66,9 @@ profiles:
         hooks:
           before:
             - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "mediawiki-138", "-n" ]
+                command: [ "./helmfile-values", "-e", "local", "-r", "mediawiki-139", "-n" ]
 metadata:
-  name: mediawiki-138
+  name: mediawiki-139
 
 ---
 


### PR DESCRIPTION
The local skaffold conf still uses mw 1.38 even though we already use 1.39 locally as the main mw release.

Also I renamed the Makefile target so that it is obvious which mw version is gonna get deployed (I got bitten by this several times now :P)