### PR TITLE
tf: uptime for CirrusSearch backed MediaWiki api

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-uptime-5
+- Add uptime check for cirrussearch backed mediawiki api endpoint
+
 # tf-module-buckets-1
 - Re-add retention policy on backup bucket
 

--- a/tf/modules/uptime/main.tf
+++ b/tf/modules/uptime/main.tf
@@ -22,6 +22,14 @@ resource "google_monitoring_uptime_check_config" "https-content-uptime-check" {
 
   content_matchers {
     content = each.value.content
+    matcher = each.value.matcher
+    dynamic "json_path_matcher" {
+      for_each = each.value.matcher == "NOT_MATCHES_JSON_PATH" ? toset([1]) : toset([])
+      content {
+         json_matcher = each.value.json_matcher
+         json_path = each.value.json_path
+      }
+    }
   }
 }
 

--- a/tf/modules/uptime/variables.tf
+++ b/tf/modules/uptime/variables.tf
@@ -40,12 +40,14 @@ locals {
       host          = "www.${var.target_wbaas_hostname}"
       path          = "/"
       content      = "doesn't work properly without JavaScript enabled"
+      matcher = "CONTAINS_STRING"
     },
     "https-www-${local.target_wbaas_name}-api-health" = {
       name          = "https-www-${local.target_wbaas_name}-api-health"
       host          = "api.${var.target_wbaas_hostname}"
       path          = "/healthz"
       content      = "It's Alive"
+      matcher = "CONTAINS_STRING"
     },
 
     /* WIKI CHECKS */
@@ -54,48 +56,65 @@ locals {
       host          = var.target_wiki
       path          = "/wiki/Special:Version"
       content      = "Adam Shorland"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-query" = {
       name          = "https-${local.target_name}-query"
       host          = var.target_wiki
       path          = "/query"
       content      = "Special:MyLanguage/Wikidata:SPARQL_query_service"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-query-sparql" = {
       name          = "https-${local.target_name}-query-sparql"
       host          = var.target_wiki
       path          = "/query/sparql"
       content      = "http://www.w3.org/1999/02/22-rdf-syntax-ns"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-cradle" = {
       name          = "https-${local.target_name}-cradle"
       host          = var.target_wiki
       path          = "/tools/cradle"
       content      = "<script src=\"vue.js\"></script>"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-quickstatements" = {
       name          = "https-${local.target_name}-quickstatements"
       host          = var.target_wiki
       path          = "/tools/quickstatements"
       content      = "magnusmanske"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-widar" = {
       name          = "https-${local.target_name}-widar"
       host          = var.target_wiki
       path          = "/tools/widar"
       content      = "You have not authorized Widar"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-wikibase-wbgetentities" = {
       name          = "https-${local.target_name}-wikibase-wbgetentities"
       host          = var.target_wiki
       path          = "/w/api.php?action=wbgetentities&format=json&errorformat=plaintext&uselang=en&ids=${var.wikibase_itempage_item}"
       content      = "${var.wikibase_itempage_content}"
+      matcher = "CONTAINS_STRING"
     },
     "https-${local.target_name}-wikibase-itempage" = {
       name          = "https-${local.target_name}-wikibase-itempage"
       host          = var.target_wiki
       path          = "/wiki/Item:${var.wikibase_itempage_item}"
       content      = "${var.wikibase_itempage_content}"
-    }
+      matcher = "CONTAINS_STRING"
+    },
+    "https-${local.target_name}-wikibase-cirrussearch" = {
+      name          = "https-${local.target_name}-wikibase-cirrussearch"
+      host          = var.target_wiki
+      path          = "/w/api.php?action=cirrus-mapping-dump&format=json"
+      matcher       = "NOT_MATCHES_JSON_PATH"
+      json_matcher     = "REGEX_MATCH"
+      json_path  = "$.error"
+      content = ".*"
+    },
   }
 }


### PR DESCRIPTION
Add uptime check and alert to uptime module for a
mediawiki api endpoint that depends on being able to contact elasticsearch.

This endpoint was chosen because it appears to always contact elasticsearch in order to obtain the mapping.

In order to determine success or failure we have to inspect the actual JSON response from the api since even errors return an HTTP status 200.

Doing this has resulted in exposing more of the underlying resources to the local configuration and added to the complexity of reading the resource and the module variables. However, it does ensure consistency with our other uptime checks and alerts.

This commit doesn't see this module actually being used