### PR TITLE
k8s: beyond-notability.wikibase.cloud to 1.38

### DIFF
--- a/k8s/helmfile/env/production/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/production/platform-nginx.nginx.conf
@@ -175,6 +175,7 @@ map $host $mwversion {
         "wiki.data.foundation" "138-app";
         "hestiaai-test.wikibase.cloud" "138-app";
         "wikibase.juncture-digital.org" "138-app";
+        "beyond-notability.wikibase.cloud" "138-app";
 }
 # Figure out which group of backends we might want to send the request to based on uri
 # TODO add Special:EntityData???


### PR DESCRIPTION
This patch hopes to test if we see the issues described in T334912 go away by reverting to this wiki using 1.38 mediawiki