### PR TITLE
chore(k8s): update api image version to 8x.11.1 in staging and local

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.11.0"
+  tag: "8x.11.1"
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.11.0"
+  tag: "8x.11.1"
 
 ingress:
   tls:


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T333559

Changes in `api`: https://github.com/wbstack/api/compare/8x.11.0...8x.11.1