### PR TITLE
chore(k8s): update api image version to 8x.11.1 in production

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.11.0"
+  tag: "8x.11.1"
 
 replicaCount:
   web: 1


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T333559

Changes in `api`: https://github.com/wbstack/api/compare/8x.11.0...8x.11.1