### PR TITLE
fix(tf): remove duplicate alarm definitions

### DIFF
--- a/tf/env/production/metric-alarms.tf
+++ b/tf/env/production/metric-alarms.tf
@@ -1,6 +1,0 @@
-module "metric-alarms" {
-  source                      = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/metric-alarms?ref=tf-module-metric-alarms-1"
-  cluster_name                = "wbaas-3"
-  environment                 = "production"
-  monitoring_email_group_name = google_monitoring_notification_channel.monitoring_email_group.name
-}

--- a/tf/env/staging/metric-alarms.tf
+++ b/tf/env/staging/metric-alarms.tf
@@ -1,6 +1,0 @@
-module "metric-alarms" {
-  source                      = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/metric-alarms?ref=tf-module-metric-alarms-1"
-  cluster_name                = "wbaas-2"
-  environment                 = "staging"
-  monitoring_email_group_name = google_monitoring_notification_channel.monitoring_email_group.name
-}


### PR DESCRIPTION
This was missed in #877 which means current `main` would create the same alarm twice.