### PR TITLE
chore(monitoring): wait for 5 minutes of metric absence before triggering alarm

### DIFF
--- a/tf/modules/monitoring/metric-alarms.tf
+++ b/tf/modules/monitoring/metric-alarms.tf
@@ -8,7 +8,7 @@ locals {
       trigger_count           = 1
       threshold_value         = 1
       duration                = "60s"
-      condition_absent        = "120s"
+      condition_absent        = "300s"
     },
   }
 }


### PR DESCRIPTION
Currently, an alarm for ES health is raised when there has been a period of 2 minutes without any data. It seems this is relatively common in production and data just takes a while to arrive there.

Most alarms that are triggered right now last around 30 seconds, so raising this to 5 minutes should be a very conservative option for silencing these false positives.