### PR TITLE
fix(skaffold): remove references to deleted 1.38 mediawiki release

### DIFF
--- a/skaffold/README.md
+++ b/skaffold/README.md
@@ -40,7 +40,7 @@ This will build local images and apply them to the cluster. Every time you make 
 Currently the following services are hooked up to skaffold:
 
 - [ui](https://github.com/wbstack/ui/)
-- [mediawiki-138](https://github.com/wbstack/mediawiki/)
+- [mediawiki-139](https://github.com/wbstack/mediawiki/)
 - [api](https://github.com/wbstack/api)
 - [queryservice-gateway](https://github.com/wbstack/queryservice-gateway)
 - [queryservice-ui](https://github.com/wbstack/queryservice-ui)

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -54,46 +54,6 @@ profiles:
       kubeContext: minikube-wbaas
       helm:
         releases:
-          - name: mediawiki-138
-            chartPath: ./../../charts/charts/mediawiki
-            valuesFiles:
-              - ".tmp.values.mediawiki-138.yaml"
-              - NeverPull.yaml
-            artifactOverrides:
-              image: local/skaffold/wbaas/mediawiki
-            imageStrategy:
-              helm: {}
-        hooks:
-          before:
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "mediawiki-138", "-n" ]
-metadata:
-  name: mediawiki-138
-
----
-
-apiVersion: skaffold/v2beta23
-kind: Config
-profiles:
-  - name: local
-    activation:
-      - kubeContext: minikube-wbaas
-    build:
-      artifacts:
-        - image: local/skaffold/wbaas/mediawiki
-          context: ./../../mediawiki
-          docker:
-            buildArgs:
-              LOCALIZATION_CACHE_THREAD_COUNT: 4
-              LOCALIZATION_CACHE_ADDITIONAL_PARAMS: "--lang=en,sv,de"
-              INSTALL_PROFILING_DEPS: 1
-              INSTALL_XDEBUG: 1
-      local:
-        useDockerCLI: true
-    deploy:
-      kubeContext: minikube-wbaas
-      helm:
-        releases:
           - name: mediawiki-139
             chartPath: ./../../charts/charts/mediawiki
             valuesFiles:


### PR DESCRIPTION
Referencing the inexistent 1.38 release somehow had my local skaffold setup end up in an infinite loop of comparing configuration files.

This PR removes the release info for 1.38, after which my local setup started working as expected again.