### PR TITLE
(proposal) ADR: Terraform style conventions

### DIFF
--- a/doc/adr/0009-terraform-style-conventions.md
+++ b/doc/adr/0009-terraform-style-conventions.md
@@ -4,7 +4,7 @@ Date: 2023-05-16
 
 ## Status
 
-proposed
+accepted
 
 ## Context
 

--- a/doc/adr/0009-terraform-style-conventions.md
+++ b/doc/adr/0009-terraform-style-conventions.md
@@ -1,0 +1,20 @@
+# 9) Terraform style conventions {#adr_0009}
+
+Date: 2023-05-16
+
+## Status
+
+proposed
+
+## Context
+
+When adopting Terraform as part of our infrastructure as code setup in the past, we did not settle on any code style format conventions. Since there is a built-in command to Terraform to streamline source files according to the officially recommended [style conventions](https://developer.hashicorp.com/terraform/language/syntax/style), we could make use of this to make our configuration more readable, especially for code review in pull requests.
+
+## Decision
+
+We use `terraform fmt` with it's defaults to auto-format files containing the Terraform Configuration Language. For now this has to be done manually - git hooks to run it automatically and/or a CI test to check for it are welcome.
+
+## Consequences
+
+To streamline all of the existing configuration we create a PR which formats all of the code. As mentioned above, right now it's up to the engineers to run this step on their machines before checking in Terraform code.
+

--- a/doc/adr/index.md
+++ b/doc/adr/index.md
@@ -20,6 +20,7 @@ Current ADRs include:
 - [6) Production as the configuration base case for helmfile values](0006-helmfile-base-values.md)
 - [7) Application level monitoring using Prometheus](0007-monitoring-prometheus.md)
 - [8) Deploying a service mesh to the Kubernetes Cluster](0008-service-mesh.md)
+- [9) Terraform style conventions](0009-terraform-style-conventions.md)
 <!-- toc-end -->
 
 ---


### PR DESCRIPTION
This PR contains a new ADR, proposing to make use of the default terraform style conventions.
Additionally, all existing terraform code has been reformatted with `terraform fmt -recursive`.

