### PR TITLE
k8s: reduce secondary sql replica count to 0

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -61,7 +61,7 @@ primary:
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 secondary:
-  replicaCount: 1
+  replicaCount: 0
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Test if the site correctly falls back to being fully functional just using the master if there is no sql secondary to connect to.