### PR TITLE
k8s staging: secondary sql replica count to 1

### DIFF
--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -51,6 +51,7 @@ primary:
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 secondary:
+  replicaCount: 1
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
In order to practice restoring some data on the secondary let's scale up the replica count so we have something to restore to