### PR TITLE
k8s: increase secondary sql replica count to 1

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -61,7 +61,7 @@ primary:
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 secondary:
-  replicaCount: 0
+  replicaCount: 1
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
Lets bring this up and try to restore data into it