### PR TITLE
fix(helmfile): environments and releases cannot be defined within the same YAML part

### DIFF
--- a/k8s/helmfile/cert-manager.yaml
+++ b/k8s/helmfile/cert-manager.yaml
@@ -16,6 +16,8 @@ environments:
     values:
       - ./env/local/private.yaml
 
+---
+
 releases:
   - name: cert-manager
     namespace: cert-manager

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -55,6 +55,8 @@ helmfiles:
     values:
       - foo: null
 
+---
+
 templates:
   default: &default_release
     missingFileHandler: Error


### PR DESCRIPTION
Since upgrading Helmfile to `0.153.1` I was seeing this warning on every interaction:

```
Warning: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part                                                                  
Warning: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part                                                                  
Warning: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part                                                                  
Warning: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part
```

This PR introduces separators and gets rid of the warnings. It diffs cleanly against every env for me.