### PR TITLE
use wbaas-backup chart v0.0.6

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -209,7 +209,7 @@ releases:
   - name: wbaas-backup
     namespace: default
     chart: wbstack/wbaas-backup
-    version: 0.0.5
+    version: 0.0.6
     <<: *default_release
 
   - name: kube-prometheus-stack


### PR DESCRIPTION
Uses wbaas-backup v0.0.6 which introduces more verbosity settings and a table overwrite flag for restoring
