### PR TITLE
chore(sql): set production replica count to 0

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -61,7 +61,7 @@ primary:
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 secondary:
-  replicaCount: 1
+  replicaCount: 0
   resources:
     requests:
       cpu: '2'


### PR DESCRIPTION
Temporary fix to keep the secondary from responding with stale data.