### PR TITLE
prod: deploy mediawiki URI fix

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "1.39-7.4-20230426-0"
+  tag: "1.39-7.4-20230522-0"
 
 replicaCount:
   backend: 1


### PR DESCRIPTION
https://phabricator.wikimedia.org/T327752

Deploys mediawiki image tag "1.39-7.4-20230522-0" on production