### PR TITLE
chore(sql): reenable production replica

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -61,7 +61,7 @@ primary:
     pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 secondary:
-  replicaCount: 0
+  replicaCount: 1
   resources:
     requests:
       cpu: '2'


### PR DESCRIPTION
We'll need this when choosing our next attempts on fixing the incident.