### PR TITLE
chore(k8s): replace sql secondary references with primary ones

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -16,7 +16,7 @@ platform:
 queue:
   mw:
     db:
-      readHost: sql-mariadb-secondary.default.svc.cluster.local
+      readHost: sql-mariadb-primary.default.svc.cluster.local # FIXME: point back to replica when working
       writeHost: sql-mariadb-primary.default.svc.cluster.local
       # database: someDbName
       username: mediawiki-db-manager
@@ -80,7 +80,7 @@ app:
     cachedb: {{ .Values.services.redis.databases.apiCacheDb }}
   db:
     connection: mysql
-    readHost: sql-mariadb-secondary.default.svc.cluster.local
+    readHost: sql-mariadb-primary.default.svc.cluster.local # FIXME: point back to replica when working
     writeHost: sql-mariadb-primary.default.svc.cluster.local
     port: 3306
     name: {{ .Values.services.sql.api.db }}

--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -26,7 +26,7 @@ mw:
   settings:
     allowedProxyCidr: "10.108.0.0/14"
   db:
-    replica: sql-mariadb-secondary.default.svc.cluster.local
+    replica: sql-mariadb-primary.default.svc.cluster.local # FIXME: point back to replica when working
     master: sql-mariadb-primary.default.svc.cluster.local
   mail:
     domain: "wikibase.cloud"


### PR DESCRIPTION
This will allow us to work on the secondary without affecting anything else.