### PR TITLE
chore(mw): bump production image

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "1.39-7.4-20230426-0"
+  tag: '1.39-7.4-20230524-0'
 
 replicaCount:
   backend: 1


### PR DESCRIPTION
Effectively disabling the secondary SQL node for production MediaWiki pods.