### PR TITLE
chore(mediawiki): start reading from replica again

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -26,7 +26,7 @@ mw:
   settings:
     allowedProxyCidr: "10.108.0.0/14"
   db:
-    replica: '' # FIXME: point back to replica when working
+    replica: sql-mariadb-secondary.default.svc.cluster.local
     master: sql-mariadb-primary.default.svc.cluster.local
   mail:
     domain: "wikibase.cloud"


### PR DESCRIPTION
After manual intervention, the secondary is ready to use again.