### PR TITLE
chore(api): start reading from replica again

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -16,7 +16,7 @@ platform:
 queue:
   mw:
     db:
-      readHost: sql-mariadb-primary.default.svc.cluster.local # FIXME: point back to replica when working
+      readHost: sql-mariadb-secondary.default.svc.cluster.local
       writeHost: sql-mariadb-primary.default.svc.cluster.local
       # database: someDbName
       username: mediawiki-db-manager
@@ -80,7 +80,7 @@ app:
     cachedb: {{ .Values.services.redis.databases.apiCacheDb }}
   db:
     connection: mysql
-    readHost: sql-mariadb-primary.default.svc.cluster.local # FIXME: point back to replica when working
+    readHost: sql-mariadb-secondary.default.svc.cluster.local
     writeHost: sql-mariadb-primary.default.svc.cluster.local
     port: 3306
     name: {{ .Values.services.sql.api.db }}


### PR DESCRIPTION
After manual intervention, the secondary is ready to use again.