### PR TITLE
chore(backup): bump version to 0.2.0, including --overwrite-tables flag

### DIFF
--- a/k8s/helmfile/env/local/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/wbaas-backup.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: v0.1.10
+  tag: v0.2.0
 
 job:
   failedJobsHistoryLimit: 1

--- a/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
@@ -1,6 +1,6 @@
 image:
   repository: ghcr.io/wmde/wbaas-backup
-  tag: v0.1.10
+  tag: v0.2.0
   pullPolicy: Always
 
 job:

--- a/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: v0.1.10
+  tag: v0.2.0
 
 storage:
   scratchDiskSpace: 8Gi


### PR DESCRIPTION
Makes https://github.com/wmde/wbaas-backup/pull/22 available