### PR TITLE
Deploy MediaWiki job queue to staging

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.11.1"
+  tag: "8x.12.0"
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.11.1"
+  tag: "8x.12.0"
 
 ingress:
   tls:

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -147,8 +147,8 @@ releases:
       - tls: {{ .Values.tls | toYaml }}
 
   - name: api
-    chart: ./../../../charts/charts/api
-    version: 0.20.2
+    chart: wbstack/api
+    version: 0.21.0
     namespace: default
     <<: *default_release
 
@@ -160,7 +160,7 @@ releases:
 
   - name: mediawiki-139
     namespace: default
-    chart: ./../../../charts/charts/mediawiki
+    chart: wbstack/mediawiki
     version: 0.10.6
     <<: *default_release
 

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -147,7 +147,7 @@ releases:
       - tls: {{ .Values.tls | toYaml }}
 
   - name: api
-    chart: wbstack/api
+    chart: ./../../../charts/charts/api
     version: 0.20.2
     namespace: default
     <<: *default_release
@@ -160,7 +160,7 @@ releases:
 
   - name: mediawiki-139
     namespace: default
-    chart: wbstack/mediawiki
+    chart: ./../../../charts/charts/mediawiki
     version: 0.10.6
     <<: *default_release
 

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -148,7 +148,7 @@ releases:
 
   - name: api
     chart: wbstack/api
-    version: 0.21.0
+    version: {{ ternary "0.21.0" "0.20.2" (ne .Environment.Name "production") }}
     namespace: default
     <<: *default_release
 

--- a/tf/env/local/namespaces.tf
+++ b/tf/env/local/namespaces.tf
@@ -3,3 +3,16 @@ resource "kubernetes_namespace" "api-job-namespace" {
     name = "api-jobs"
   }
 }
+
+resource "kubernetes_resource_quota" "api-jobs-podquota" {
+  metadata {
+    name      = "api-jobs-podquota"
+    namespace = kubernetes_namespace.api-job-namespace.metadata[0].name
+  }
+  spec {
+    hard = {
+      pods = 2
+    }
+    scopes = ["BestEffort"]
+  }
+}

--- a/tf/env/local/namespaces.tf
+++ b/tf/env/local/namespaces.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "api-job-namespace" {
+  metadata {
+    name = "api-jobs"
+  }
+}

--- a/tf/env/local/secrets-api.tf
+++ b/tf/env/local/secrets-api.tf
@@ -40,3 +40,8 @@ resource "kubernetes_secret" "api-app-secrets" {
     "api-app-jwt-secret" = random_password.api-app-jwt-secret.result
   }
 }
+
+moved {
+  from = kubernetes_secret.api-app-secrets
+  to   = kubernetes_secret.api-app-secrets["default"]
+}

--- a/tf/env/local/secrets-api.tf
+++ b/tf/env/local/secrets-api.tf
@@ -6,12 +6,12 @@ resource "tls_private_key" "api-passport" {
 
 resource "kubernetes_secret" "api-passport-keys" {
   metadata {
-    name = "api-passport-keys"
+    name      = "api-passport-keys"
     namespace = "default"
   }
 
   binary_data = {
-    "oauth-public.key" = base64encode(tls_private_key.api-passport.public_key_pem)
+    "oauth-public.key"  = base64encode(tls_private_key.api-passport.public_key_pem)
     "oauth-private.key" = base64encode(tls_private_key.api-passport.private_key_pem)
   }
 }
@@ -29,13 +29,14 @@ resource "random_password" "api-app-jwt-secret" {
 }
 
 resource "kubernetes_secret" "api-app-secrets" {
+  for_each = toset(["default", "api-jobs"])
   metadata {
-    name = "api-app-secrets"
-    namespace = "default"
+    name      = "api-app-secrets"
+    namespace = each.value
   }
 
   data = {
-    "api-app-key" = random_password.api-app-key.result
+    "api-app-key"        = random_password.api-app-key.result
     "api-app-jwt-secret" = random_password.api-app-jwt-secret.result
   }
 }

--- a/tf/env/local/secrets-recapcha.tf
+++ b/tf/env/local/secrets-recapcha.tf
@@ -12,6 +12,11 @@ resource "kubernetes_secret" "recaptcha-v3-dev-secrets" {
   }
 }
 
+moved {
+  from = kubernetes_secret.recaptcha-v3-dev-secrets
+  to   = kubernetes_secret.recaptcha-v3-dev-secrets["default"]
+}
+
 resource "kubernetes_secret" "recaptcha-v2-dev-secrets" {
   for_each = toset(["default", "api-jobs"])
   metadata {
@@ -24,4 +29,9 @@ resource "kubernetes_secret" "recaptcha-v2-dev-secrets" {
     "site_key" = var.recaptcha_v2_dev_site_key,
     "secret_key" = var.recaptcha_v2_dev_secret
   }
+}
+
+moved {
+  from = kubernetes_secret.recaptcha-v2-dev-secrets
+  to   = kubernetes_secret.recaptcha-v2-dev-secrets["default"]
 }

--- a/tf/env/local/secrets-recapcha.tf
+++ b/tf/env/local/secrets-recapcha.tf
@@ -1,8 +1,9 @@
 resource "kubernetes_secret" "recaptcha-v3-dev-secrets" {
+  for_each = toset(["default", "api-jobs"])
   metadata {
     name = "recaptcha-v3-dev-secrets"
     # default as staging
-    namespace = "default"
+    namespace = each.value
   }
 
   data = {
@@ -12,10 +13,11 @@ resource "kubernetes_secret" "recaptcha-v3-dev-secrets" {
 }
 
 resource "kubernetes_secret" "recaptcha-v2-dev-secrets" {
+  for_each = toset(["default", "api-jobs"])
   metadata {
     name = "recaptcha-v2-dev-secrets"
     # default as staging
-    namespace = "default"
+    namespace = each.value
   }
 
   data = {

--- a/tf/env/local/secrets-redis.tf
+++ b/tf/env/local/secrets-redis.tf
@@ -7,13 +7,14 @@ resource "random_password" "redis-password" {
 
 # Used by the sql service for initial setup
 resource "kubernetes_secret" "redis-password" {
+  for_each = toset(["default", "api-jobs"])
   metadata {
-    name = "redis-password"
-    namespace = "default"
+    name      = "redis-password"
+    namespace = each.value
   }
 
   binary_data = {
     "password" = base64encode(random_password.redis-password.result)
   }
-  
+
 }

--- a/tf/env/local/secrets-redis.tf
+++ b/tf/env/local/secrets-redis.tf
@@ -18,3 +18,8 @@ resource "kubernetes_secret" "redis-password" {
   }
 
 }
+
+moved {
+  from = kubernetes_secret.redis-password
+  to   = kubernetes_secret.redis-password["default"]
+}

--- a/tf/env/local/secrets-sql.tf
+++ b/tf/env/local/secrets-sql.tf
@@ -1,6 +1,6 @@
 # Use for sql dbs
 resource "random_password" "sql-passwords" {
-  for_each = var.sql-passwords
+  for_each         = var.sql-passwords
   length           = 32
   special          = true
   override_special = "_%@"
@@ -8,29 +8,31 @@ resource "random_password" "sql-passwords" {
 
 # Used by the sql service for initial setup
 resource "kubernetes_secret" "sql-secrets-passwords" {
+  for_each = toset(["default", "api-jobs"])
   metadata {
-    name = "sql-secrets-passwords"
-    namespace = "default"
+    name      = "sql-secrets-passwords"
+    namespace = each.value
   }
 
   binary_data = {
-    "mariadb-root-password" = base64encode(random_password.sql-passwords["root"].result)
+    "mariadb-root-password"        = base64encode(random_password.sql-passwords["root"].result)
     "mariadb-replication-password" = base64encode(random_password.sql-passwords["replication"].result)
   }
-  
+
 }
 
 # Used by the init script on sql services for user and permissions setup
 resource "kubernetes_secret" "sql-secrets-init-passwords" {
+  for_each = toset(["default", "api-jobs"])
   metadata {
-    name = "sql-secrets-init-passwords"
-    namespace = "default"
+    name      = "sql-secrets-init-passwords"
+    namespace = each.value
   }
 
   binary_data = {
-    "SQL_INIT_PASSWORD_API" = base64encode(random_password.sql-passwords["api"].result)
-    "SQL_INIT_PASSWORD_MW" = base64encode(random_password.sql-passwords["mediawiki-db-manager"].result)
+    "SQL_INIT_PASSWORD_API"     = base64encode(random_password.sql-passwords["api"].result)
+    "SQL_INIT_PASSWORD_MW"      = base64encode(random_password.sql-passwords["mediawiki-db-manager"].result)
     "SQL_INIT_PASSWORD_BACKUPS" = base64encode(random_password.sql-passwords["backup-manager"].result)
   }
-  
+
 }

--- a/tf/env/local/secrets-sql.tf
+++ b/tf/env/local/secrets-sql.tf
@@ -18,7 +18,11 @@ resource "kubernetes_secret" "sql-secrets-passwords" {
     "mariadb-root-password"        = base64encode(random_password.sql-passwords["root"].result)
     "mariadb-replication-password" = base64encode(random_password.sql-passwords["replication"].result)
   }
+}
 
+moved {
+  from = kubernetes_secret.sql-secrets-passwords
+  to   = kubernetes_secret.sql-secrets-passwords["default"]
 }
 
 # Used by the init script on sql services for user and permissions setup
@@ -35,4 +39,9 @@ resource "kubernetes_secret" "sql-secrets-init-passwords" {
     "SQL_INIT_PASSWORD_BACKUPS" = base64encode(random_password.sql-passwords["backup-manager"].result)
   }
 
+}
+
+moved {
+  from = kubernetes_secret.sql-secrets-init-passwords
+  to   = kubernetes_secret.sql-secrets-init-passwords["default"]
 }

--- a/tf/env/staging/kubernetes-secrets.tf
+++ b/tf/env/staging/kubernetes-secrets.tf
@@ -21,6 +21,6 @@ module "wbaas2-k8s-secrets" {
   api_passport_private_key          = tls_private_key.api-passport.private_key_pem
   api_app_key                       = random_password.api-app-key.result
   api_app_jwt_secret                = random_password.api-app-jwt-secret.result
-  mediawiki_secret_namespaces       = ["default", kubernetes_namespace.api-job-namespace.name]
+  mediawiki_secret_namespaces       = ["default", kubernetes_namespace.api-job-namespace.metadata[0].name]
   logical_backup_openssl_secret     = random_password.logical_backup_random_password.result
 }

--- a/tf/env/staging/kubernetes-secrets.tf
+++ b/tf/env/staging/kubernetes-secrets.tf
@@ -1,5 +1,5 @@
 module "wbaas2-k8s-secrets" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/k8s-secrets?ref=tf-module-k8s-secrets-1"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/k8s-secrets?ref=tf-module-k8s-secrets-2"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }
@@ -21,5 +21,6 @@ module "wbaas2-k8s-secrets" {
   api_passport_private_key          = tls_private_key.api-passport.private_key_pem
   api_app_key                       = random_password.api-app-key.result
   api_app_jwt_secret                = random_password.api-app-jwt-secret.result
+  mediawiki_secret_namespaces       = ["default", kubernetes_namespace.api-job-namespace.name]
   logical_backup_openssl_secret     = random_password.logical_backup_random_password.result
 }

--- a/tf/env/staging/namespaces.tf
+++ b/tf/env/staging/namespaces.tf
@@ -3,3 +3,16 @@ resource "kubernetes_namespace" "api-job-namespace" {
     name = "api-jobs"
   }
 }
+
+resource "kubernetes_resource_quota" "api-jobs-podquota" {
+  metadata {
+    name      = "api-jobs-podquota"
+    namespace = kubernetes_namespace.api-job-namespace.metadata[0].name
+  }
+  spec {
+    hard = {
+      pods = 8
+    }
+    scopes = ["BestEffort"]
+  }
+}

--- a/tf/env/staging/namespaces.tf
+++ b/tf/env/staging/namespaces.tf
@@ -1,0 +1,5 @@
+resource "kubernetes_namespace" "api-job-namespace" {
+  metadata {
+    name = "api-jobs"
+  }
+}


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T330389

This currently fails deploying with

```
kubernetes_namespace.api-job-namespace: Creating...
╷
│ Error: Post "http://localhost/api/v1/namespaces": dial tcp 127.0.0.1:80: connect: connection refused
│ 
│   with kubernetes_namespace.api-job-namespace,
│   on namespaces.tf line 1, in resource "kubernetes_namespace" "api-job-namespace":
│    1: resource "kubernetes_namespace" "api-job-namespace" {
```

which seems to be an issue in the terraform-gke-provider: https://github.com/hashicorp/terraform-provider-kubernetes/issues/1028