### PR TITLE
k8s: fix api helmfile release version

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -148,7 +148,7 @@ releases:
 
   - name: api
     chart: wbstack/api
-    version: {{ ternary "0.21.0" "0.20.2" (ne .Environment.Name "production") }}
+    version: {{ if eq .Environment.Name "production" }}"0.20.2"{{else}}"0.21.0"{{end}}
     namespace: default
     <<: *default_release
 


### PR DESCRIPTION
Current ternary definition appears to not work for production. Let's try the more verbose if, else and end syntax. This should be tested by a second developer to apply cleanly to both environments before merging