### PR TITLE
k8s: Use forked ES6 chart and remove ES7

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -113,15 +113,8 @@ releases:
 
   - name: elasticsearch
     namespace: default
-    chart: elastic/elasticsearch
-    version: 6.8.22
-    <<: *default_release
-
-  - name: elasticsearch-honey
-    namespace: default
-    chart: elastic/elasticsearch
-    version: 7.10.2
-    installed: {{ ne .Environment.Name "production" | toYaml }}
+    chart: wbstack/elasticsearch
+    version: 6.8.22-wmde1
     <<: *default_release
 
   - name: redis


### PR DESCRIPTION
This will move us to using our forked ES6 chart
which is compatible with kubernetes 1.25+

This also stops helmfile tracking our ES7 release
on staging. After merging this the ES7 release
will need to manually be cleaned up with helm

Bug: T338298