### PR TITLE
fix(tf): smtp credentials are missing from additional namespaces

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-k8s-secrets-3
+- Export missing `smtp-credentials` secret to all given namespaces
+
 # tf-module-k8s-secrets-2
 - Allow consumers to export secrets used by `api` to multiple namespaces
 

--- a/tf/modules/k8s-secrets/main.tf
+++ b/tf/modules/k8s-secrets/main.tf
@@ -1,13 +1,19 @@
 resource "kubernetes_secret" "smtp-credentials" {
+  for_each = toset(var.mediawiki_secret_namespaces)
   metadata {
     name      = "smtp-credentials"
-    namespace = "default"
+    namespace = each.value
   }
 
   data = {
     "username" = var.smtp_username
     "password" = var.smtp_password
   }
+}
+
+moved {
+  from = kubernetes_secret.smtp-credentials
+  to   = kubernetes_secret.smtp-credentials["default"]
 }
 
 # Deprecated per https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account_key#example-usage-save-key-in-kubernetes-secret---deprecated


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T330389

MediaWiki jobs in the `api-jobs` namespace currently fail to start up as they fail to find a specified secret:

```
secret "smtp-credentials" not found
``` 