### PR TITLE
chore(api): update image version and increase count for queue replicas in staging

### DIFF
--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,8 @@
 image:
-  tag: "8x.12.0"
+  tag: "8x.12.1"
+
+replicaCount:
+  queue: 2
 
 ingress:
   tls:


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T330389

Raising the replica count was an ad-hoc decision agreed upon while discussing the changes in the updated API version: https://github.com/wbstack/api/pull/607