### PR TITLE
Prod: Add GKE maintenance window

### DIFF
--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -13,8 +13,8 @@ resource "google_container_cluster" "wbaas-3" {
     recurring_window {
       # timezone: UTC
       # "Every monday between 04.00 and 16.00 Berlin time"
-      start_time = "2023-06-14T02:00:00Z"
-      end_time   = "2023-06-14T14:00:00Z"
+      start_time = "1970-01-01T02:00:00Z"
+      end_time   = "1970-01-01T14:00:00Z"
       recurrence = "FREQ=WEEKLY;BYDAY=MO"
     }
   }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T338321

This PR adds a maintenance window for the production GKE cluster, which will prevent surprising node rollover most of the time. Here, times in terraform are defined in UTC.

Proposed time window: "Every monday between 04.00 and 16.00 Berlin time" - This needs agreement with the team before merging.