### PR TITLE
feat(monitoring): enable kube-state-metrics collection

### DIFF
--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -27,7 +27,7 @@ grafana:
       cpu: 100m
       memory: 128Mi
 
-# turning off all k8s component scraping as we are not
+# turning off most k8s component scraping as we are not
 # interested right now
 kubeScheduler:
   enabled: false
@@ -46,8 +46,6 @@ kubeEtcd:
 kubeProxy:
   enabled: false
 kubeStateMetrics:
-  enabled: false
+  enabled: true
 nodeExporter:
-  enabled: false
-kubeStateMetrics:
   enabled: false


### PR DESCRIPTION
When trying to monitor the deployment of #942 I noticed we currently disable collection of all Kubernetes metrics. Enabling `kube-state-metrics` will give us metrics like job count et al: https://github.com/kubernetes/kube-state-metrics/blob/31d6e8fc265b1dadf543f2ed7da27a046c50c29f/docs/README.md