### PR TITLE
chore(mw): lower resource requests for staging

### DIFF
--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -6,3 +6,33 @@ mw:
     allowedProxyCidr: "10.112.0.0/14"
   mail:
     domain: "wikibase.dev"
+
+resources:
+  web:
+    requests:
+      cpu: 100m
+      memory: 250Mi
+    limits:
+      cpu: 400m
+      memory: 750Mi
+  webapi:
+    requests:
+      cpu: 100m
+      memory: 125Mi
+    limits:
+      cpu: 500m
+      memory: 1200Mi
+  alpha:
+    requests:
+      cpu: 50m
+      memory: 40Mi
+    limits:
+      cpu: 500m
+      memory: 600Mi
+  backend:
+    requests:
+      cpu: 125m
+      memory: 200Mi
+    limits:
+      cpu: 1000m
+      memory: 1200Mi


### PR DESCRIPTION
Starting with #946 we exhaust node resources and the MediaWiki replicas cannot be scheduled anymore. This PR lowers the requests for all MediaWiki pods, leaving the existing limits in place.