### PR TITLE
tf monitoring module: fix QueryService PV alerting

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf--module-monitoring-18
+- Change QueryService PV alert alignment from sum to none
+
 # tf-module-k8s-secrets-3
 - Export missing `smtp-credentials` secret to all given namespaces
 

--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-# tf--module-monitoring-18
+# tf-module-monitoring-18
 - Change QueryService PV alert alignment from sum to none
 
 # tf-module-k8s-secrets-3

--- a/tf/modules/monitoring/queryservice-pv.tf
+++ b/tf/modules/monitoring/queryservice-pv.tf
@@ -31,7 +31,7 @@ resource "google_monitoring_alert_policy" "alert_policy_queryservice_pv_critical
       aggregations {
         alignment_period     = "120s"
         per_series_aligner   = "ALIGN_MEAN"
-        cross_series_reducer = "REDUCE_SUM"
+        cross_series_reducer = "REDUCE_NONE"
       }
 
       trigger {


### PR DESCRIPTION
The cross_series_reducer was wrongly set to be a sum function which resulted in the unwanted sideffect of the metric doubling for windows where two series were present.

This happens, for example, when a pod changes.

Bug: T339101