### PR TITLE
staging: Use `tf-module-monitoring-18`

### DIFF
--- a/tf/env/staging/monitoring.tf
+++ b/tf/env/staging/monitoring.tf
@@ -1,5 +1,5 @@
 module "staging-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-17"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-18"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T339101
uses `tf-module-monitoring-18` on staging, fixing erronenous Query Service PV utilization alerts https://github.com/wmde/wbaas-deploy/pull/950