### PR TITLE
production: Use `tf-module-monitoring-18`

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -1,5 +1,5 @@
 module "production-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-17"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-18"
 
   providers = {
     kubernetes = kubernetes.wbaas-3


### PR DESCRIPTION
https://phabricator.wikimedia.org/T339101
uses `tf-module-monitoring-18` on production, fixing erronenous Query Service PV utilization alerts https://github.com/wmde/wbaas-deploy/pull/950