### PR TITLE
Staging+Local: Deploy new Platform API image ghcr.io/wbstack/api:8x.13.0
ghcr.io/wbstack/api:latest

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.12.4"
+  tag: 8x.13.0
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "8x.12.4"
+  tag: 8x.13.0
 
 ingress:
   tls:


### PR DESCRIPTION
This is an automated update for the `api` image in staging and local, using `8x.13.0`.

**Changes**: [fix(ci): docker meta action outputs multiline string instead of tag (#615)](https://github.com/wbstack/api/commit/9f4d8a8f2efe06786a42b77a054af1e60f077382)