### PR TITLE
chore(queryservice): bump disk size in production

### DIFF
--- a/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
@@ -19,4 +19,4 @@ persistence:
   annotations: {}
   accessMode: ReadWriteOnce
   storageClass: "premium-rwo"
-  size: "20Gi"
+  size: "40Gi"


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T340525

The actual disk usage has reached the threshold of 85% today, so we need to scale it up.