### PR TITLE
chore(queryservice): bump disk size in staging

### DIFF
--- a/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
@@ -11,3 +11,6 @@ resources:
   limits:
     cpu: 1
     memory: "3072Mi"
+
+persistence:
+  size: "21Gi"


### PR DESCRIPTION
This is increasing the disk size in staging so I can test the procedure for getting https://github.com/wmde/wbaas-deploy/pull/968 to production safely.