### PR TITLE
local: improve minikube-tunnel script

### DIFF
--- a/bin/minikube-tunnel
+++ b/bin/minikube-tunnel
@@ -2,7 +2,7 @@
 
 EXTERNAL_IP=$(minikube --profile minikube-wbaas kubectl -- -n kube-system get service ingress-nginx-controller -o template='{{.spec.clusterIP}}')
 
-trap 'kill -15 $kids; exit 143' TERM
+trap 'kill -15 $kids; exit 143' EXIT HUP INT TERM
 
 sudo socat tcp-listen:80,reuseaddr,fork tcp:"$EXTERNAL_IP":80 &
 kids=$!


### PR DESCRIPTION
Unfortunately I can't exactly pin down under which circumstances this can happen, but in the past it happened several times for me that the minikube-tunnel script remained hanging and I couldn't ctrl+c out of it.

Recently I stumbled over a [submission on HN](https://news.ycombinator.com/item?id=36400465) about using bash exit traps, and I wondered if this change would help with the above problem.

An alternative approach could be using `EXIT INT ABRT KILL TERM`

Overall this is just a minor convenience improvement. Did anyone else notice this problem as well at all?

