### PR TITLE
Staging+Local: Deploy new Platform API image 8x.14.0

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.13.0
+  tag: 8x.14.0
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.13.0
+  tag: 8x.14.0
 
 ingress:
   tls:


### PR DESCRIPTION
This is an automated update for the `api` image in staging and local, using `8x.14.0`.

**Changes**: [feat(platform-stats): provide number of recently created wikis and users (#617)](https://github.com/wbstack/api/commit/23907d4357989435000a0a5d510cb1424786c146)