### PR TITLE
Production: Deploy new Platform API image 8x.14.0

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.13.0
+  tag: 8x.14.0
 
 replicaCount:
   web: 1


### PR DESCRIPTION
This is an automated update for the `api` image in production, using `8x.14.0`.

**Changes**: [feat(platform-stats): provide number of recently created wikis and users (#617)](https://github.com/wbstack/api/commit/23907d4357989435000a0a5d510cb1424786c146)