### PR TITLE
fix(helmfile): resolve ES Chart name conflicts

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -113,8 +113,8 @@ releases:
 
   - name: elasticsearch
     namespace: default
-    chart: wbstack/elasticsearch
-    version: 6.8.22-wmde1
+    chart: wbstack/elasticsearch-legacy
+    version: 6.8.22-wmde2
     <<: *default_release
 
   - name: elasticsearch-1


### PR DESCRIPTION
Use a new version of the ES 6.8 chart, which has a new name. See https://github.com/wbstack/charts/pull/120 
