### PR TITLE
refactor(helmfile): track helmfile lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+!k8s/helmfile/cert-manager.lock
+!k8s/helmfile/helmfile.lock


### PR DESCRIPTION
Following recommended best practices, this PR introduces tracking of helmfile lockfiles:

https://helmfile.readthedocs.io/en/latest/#deps
> It is recommended to version-control all the lock files, so that they can be used in the production deployment pipeline for extra reproducibility.

Draft, because we need to merge #976 to actually generate and add them to this PR

