### PR TITLE
chore(elasticsearch): deploy ES 7.10.2 to staging

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -121,7 +121,7 @@ releases:
     namespace: default
     chart: bitnami/elasticsearch
     version: 19.10.2
-    installed: {{ eq .Environment.Name "local" | toYaml }}
+    installed: {{ ne .Environment.Name "production" | toYaml }}
     <<: *default_release
 
   - name: redis


### PR DESCRIPTION
https://phabricator.wikimedia.org/T335853

Deploys ES 7.10.2 via the bitnami chart to **staging**

