### PR TITLE
chore(revert): Revert "chore(elasticsearch): deploy ES 7.10.2 to staging (#978)"

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -121,7 +121,7 @@ releases:
     namespace: default
     chart: bitnami/elasticsearch
     version: 19.10.2
-    installed: {{ ne .Environment.Name "production" | toYaml }}
+    installed: {{ eq .Environment.Name "local" | toYaml }}
     <<: *default_release
 
   - name: redis


### PR DESCRIPTION
Reverting because staging has insufficient resources for the defined limits/requests

This reverts commit 9f916d9eaa301b1327d616e6ad38085cfececfb6.
