### PR TITLE
chore(elasticsearch): deploy ES 7.10.2 to staging

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
@@ -9,11 +9,11 @@ annotations:
 master:
   resources:
     requests:
-      cpu: "1"
-      memory: "1Gi"
+      cpu: "200m"
+      memory: "512Mi"
     limits:
-      cpu: "1"
-      memory: "1Gi"
+      cpu: "300m"
+      memory: "750Mi"
   persistence:
     enabled: true
     accessModes: [ "ReadWriteOnce" ]
@@ -23,11 +23,11 @@ master:
 data:
   resources:
     requests:
-      cpu: "2"
-      memory: "4Gi"
+      cpu: "200m"
+      memory: "512Mi"
     limits:
-      cpu: "2"
-      memory: "4Gi"
+      cpu: "300m"
+      memory: "750Mi"
   persistence:
     enabled: true
     accessModes: [ "ReadWriteOnce" ]
@@ -37,8 +37,8 @@ data:
 coordinating:
   resources:
     requests:
-      cpu: "1"
-      memory: "1Gi"
+      cpu: "200m"
+      memory: "256Mi"
     limits:
-      cpu: "1"
-      memory: "1Gi"
+      cpu: "250m"
+      memory: "512Mi"

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -121,7 +121,7 @@ releases:
     namespace: default
     chart: bitnami/elasticsearch
     version: 19.10.2
-    installed: {{ eq .Environment.Name "local" | toYaml }}
+    installed: false
     <<: *default_release
 
   - name: redis

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -121,7 +121,7 @@ releases:
     namespace: default
     chart: bitnami/elasticsearch
     version: 19.10.2
-    installed: false
+    installed: {{ ne .Environment.Name "production" | toYaml }}
     <<: *default_release
 
   - name: redis


### PR DESCRIPTION
After applying https://github.com/wmde/wbaas-deploy/pull/978 I noticed that the staging cluster wbaas-2 had too little resources available. 

This is a follow-up PR to attempt this deployment again and tweak the resources. As of the current state, scheduling works, but the pods keep getting OOM killed. Therefore I think we have to beef up our staging nodes.

