### PR TITLE
chore(minikube): adjust k8s version to 1.26.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube
 minikube-start:
-	minikube --profile minikube-wbaas start --kubernetes-version=1.25.8
+	minikube --profile minikube-wbaas start --kubernetes-version=1.26.5
 
 .PHONY: minikube-stop
 minikube-stop: # @HELP Stop the local minikube cluster


### PR DESCRIPTION
As we are now running GKE 1.26, this PR introduces using this k8s version locally too
