### PR TITLE
chore(cluster): bump staging node count to 6 so it can accomodate 2 ES clusters

### DIFF
--- a/tf/env/staging/cluster.tf
+++ b/tf/env/staging/cluster.tf
@@ -23,7 +23,7 @@ resource "google_container_cluster" "wbaas-2" {
 resource "google_container_node_pool" "wbaas-2_large" {
     cluster = "wbaas-2"
     name                = "large-pool"
-    node_count          = 3
+    node_count          = 6
     node_locations      = [
         "europe-west3-a",
     ]


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T335853

As I assume this is what we need to in production as well, this adds 3 more nodes of the same type so we can have one ES pod per node.