### PR TITLE
chore(mediawiki): new chart uses non-deprecated configuration

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -161,7 +161,7 @@ releases:
   - name: mediawiki-139
     namespace: default
     chart: wbstack/mediawiki
-    version: 0.10.6
+    version: 0.11.0
     <<: *default_release
 
   - name: queryservice-ui


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T335854

This changes configuaration so that the non-deprecated way of declaring a single ES cluster is being used (as per https://github.com/wbstack/mediawiki/pull/362).

Diffs against production like

```diff
            - name: MW_REDIS_PASSWORD                                                                                                                                                                      
              valueFrom:                                                                                                                                                                                   
                secretKeyRef:                                                                                                                                                                              
                  name: "redis-password"                                                                                                                                                                   
                  key: "password"                                                                                                                                                                          
-           - name: MW_ELASTICSEARCH_HOST                                                                                                                                                                  
+           - name: MW_DEFAULT_ELASTICSEARCH_HOST                                                                                                                                                          
              value: elasticsearch-master.default.svc.cluster.local                                                                                                                                        
-           - name: MW_ELASTICSEARCH_PORT                                                                                                                                                                  
+           - name: MW_DEFAULT_ELASTICSEARCH_PORT                                                                                                                                                          
              value: "9200"                                                                                                                                                                                
+           - name: MW_DEFAULT_ELASTICSEARCH_ES6                                                                                                                                                           
+             value: "true"                                                                                                                                                                                
            - name: MW_MAILGUN_DISABLED                                                                                                                                                                    
              value: "yes"                                                                                                                                                                                 
            - name: MW_MAILGUN_API_KEY                                                                                                                                                                     
              value: "1.234567e+06"                                                                                                                                                                        
            - name: MW_MAILGUN_DOMAIN  
```