### PR TITLE
Increase api-backend replica to 2

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -3,7 +3,7 @@ image:
 
 replicaCount:
   web: 1
-  backend: 1
+  backend: 2
   scheduler: 1
   queue: 1
 


### PR DESCRIPTION
We're seeing the api backend pod be semi regularly killed due to OOM. This should be a temporary solution to reduce the impact it has