### PR TITLE
fix(tf): color mode in xYCharts stopped persisting

### DIFF
--- a/tf/env/production/error-rate-dashboard.tf
+++ b/tf/env/production/error-rate-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "api error-rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -52,9 +49,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "mediawiki pod error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -90,9 +84,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "mediawiki error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -129,9 +120,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "queryservice error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -167,9 +155,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "ingress-nginx-controller error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -206,9 +191,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "platform-nginx error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -244,9 +226,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "mariadb error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -282,9 +261,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "tool pod error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -338,9 +314,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "ui pod error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "STACKED_BAR"

--- a/tf/env/production/es-prometheus-dashoard.tf
+++ b/tf/env/production/es-prometheus-dashoard.tf
@@ -191,9 +191,6 @@ resource "google_monitoring_dashboard" "elasticsearch-prometheus" {
                         widget = {
                             title   = "OS Load Average over 15min"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "LINE"
@@ -217,9 +214,6 @@ resource "google_monitoring_dashboard" "elasticsearch-prometheus" {
                         widget = {
                             title   = "CPU Usage % "
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "LINE"
@@ -244,9 +238,6 @@ resource "google_monitoring_dashboard" "elasticsearch-prometheus" {
                         widget = {
                             title   = "JVM Memory Pool Peak Used Bytes"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "LINE"
@@ -278,9 +269,6 @@ resource "google_monitoring_dashboard" "elasticsearch-prometheus" {
                         widget = {
                             title   = "Disk Usage %"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "LINE"
@@ -304,9 +292,6 @@ resource "google_monitoring_dashboard" "elasticsearch-prometheus" {
                         widget = {
                             title   = "Network Usage"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "LINE"
@@ -338,9 +323,6 @@ resource "google_monitoring_dashboard" "elasticsearch-prometheus" {
                         widget = {
                             title   = "Thread Pool Operations Rejected"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         plotType        = "LINE"

--- a/tf/env/production/incoming-traffic-dashboard.tf
+++ b/tf/env/production/incoming-traffic-dashboard.tf
@@ -10,9 +10,6 @@ resource "google_monitoring_dashboard" "incoming-traffic" {
                         widget = {
                             title   = "Incoming Requests"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -43,9 +40,6 @@ resource "google_monitoring_dashboard" "incoming-traffic" {
                         widget = {
                             title   = "Incoming requests by domain"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -81,9 +75,6 @@ resource "google_monitoring_dashboard" "incoming-traffic" {
                         widget = {
                             title   = "Incoming requests by httpMethod"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -119,9 +110,6 @@ resource "google_monitoring_dashboard" "incoming-traffic" {
                         widget = {
                             title   = "internal server error (5XX) response count"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"

--- a/tf/env/production/platform-summary-dashboard.tf
+++ b/tf/env/production/platform-summary-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "platform-summary" {
             widget = {
               title = "wikis"
               xyChart = {
-                chartOptions = {
-                  mode = "COLOR"
-                }
                 dataSets = [
                   {
                     minAlignmentPeriod = "86400s"
@@ -320,9 +317,6 @@ resource "google_monitoring_dashboard" "platform-summary" {
             widget = {
               title = "editors"
               xyChart = {
-                chartOptions = {
-                  mode = "COLOR"
-                }
                 dataSets = [
                   {
                     minAlignmentPeriod = "86400s"
@@ -371,9 +365,6 @@ resource "google_monitoring_dashboard" "platform-summary" {
             widget = {
               title = "edits & pages"
               xyChart = {
-                chartOptions = {
-                  mode = "COLOR"
-                }
                 dataSets = [
                   {
                     minAlignmentPeriod = "86400s"

--- a/tf/env/production/uptime-latency-dashboard.tf
+++ b/tf/env/production/uptime-latency-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Request Latency of the platform API health endpoint"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -52,9 +49,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Request Latency of Mediawiki API"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -90,9 +84,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Request latency of Queryservice"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -129,9 +120,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Request latency of Mediawiki Web Pod - Item"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -169,9 +157,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Request latency of Mediawiki Web Pod - Special:Version"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -208,9 +193,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Count of \"down\" checks of Mediawiki API"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -248,9 +230,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Count of \"down\" checks of The platform API health endpoint"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -287,9 +266,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Count of \"down\" checks of Queryservice"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -327,9 +303,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Count of \"down\" checks of Mediawiki Web Pod - Item"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -366,9 +339,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
                         widget = {
                             title   = "Count of \"down\" checks of Mediawiki Web Pod - Special:Version"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"

--- a/tf/env/production/volume-utilisation-dashboard.tf
+++ b/tf/env/production/volume-utilisation-dashboard.tf
@@ -10,9 +10,6 @@ resource "google_monitoring_dashboard" "volume-utilisation" {
                         widget = {
                             title   = "Production QueryService"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "300s"
@@ -44,9 +41,6 @@ resource "google_monitoring_dashboard" "volume-utilisation" {
                         widget = {
                             title   = "production sql"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "300s"
@@ -78,9 +72,6 @@ resource "google_monitoring_dashboard" "volume-utilisation" {
                         widget = {
                             title   = "Production Elasticsearch"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "300s"
@@ -112,9 +103,6 @@ resource "google_monitoring_dashboard" "volume-utilisation" {
                         widget = {
                             title   = "sql-logic-backup scratch-disk space"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         legendTemplate  = "Used"

--- a/tf/env/production/workload-technical-metrics-dashboard.tf
+++ b/tf/env/production/workload-technical-metrics-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "Mediawiki - Max CPU Limit Utilization"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -51,9 +48,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "API - Memory Limit Utilization "
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -90,9 +84,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "SQL/Redis/ElasticSearch/Queryservice - Max Memory Limit Utilization "
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -132,9 +123,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "SQL/Redis/ElasticSearch/Queryservice - Max Cpu Limit Utilization "
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -170,9 +158,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "logging/user/production-site-request-count (filtered) [SUM]"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -207,9 +192,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "Mediawiki - Max Memory Limit Utilization"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -246,9 +228,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
                         widget = {
                             title   = "API - Max CPU Limit Utilization "
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"

--- a/tf/env/staging/error-rate-dashboard.tf
+++ b/tf/env/staging/error-rate-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "api error-rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -52,9 +49,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "mediawiki pod error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -90,9 +84,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "mediawiki error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -129,9 +120,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "queryservice error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -167,9 +155,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "ingress-nginx-controller error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -206,9 +191,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "platform-nginx error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -244,9 +226,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "mariadb error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -282,9 +261,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "tool pod error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"
@@ -338,9 +314,6 @@ resource "google_monitoring_dashboard" "error-rate" {
                         widget = {
                             title   = "ui pod error rate"
                             xyChart = {
-                                chartOptions      = {
-                                    mode = "COLOR"
-                                }
                                 dataSets          = [
                                     {
                                         minAlignmentPeriod = "60s"

--- a/tf/env/staging/platform-summary-dashboard.tf
+++ b/tf/env/staging/platform-summary-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "platform-summary" {
             widget = {
               title = "wikis"
               xyChart = {
-                chartOptions = {
-                  mode = "COLOR"
-                }
                 dataSets = [
                   {
                     minAlignmentPeriod = "86400s"
@@ -320,9 +317,6 @@ resource "google_monitoring_dashboard" "platform-summary" {
             widget = {
               title = "editors"
               xyChart = {
-                chartOptions = {
-                  mode = "COLOR"
-                }
                 dataSets = [
                   {
                     minAlignmentPeriod = "86400s"
@@ -371,9 +365,6 @@ resource "google_monitoring_dashboard" "platform-summary" {
             widget = {
               title = "edits & pages"
               xyChart = {
-                chartOptions = {
-                  mode = "COLOR"
-                }
                 dataSets = [
                   {
                     minAlignmentPeriod = "86400s"

--- a/tf/env/staging/uptime-latency-dashboard.tf
+++ b/tf/env/staging/uptime-latency-dashboard.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Request latency of the platform API health"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -52,9 +49,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Request Latency of Queryservice"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -91,9 +85,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Request latency of Mediawiki API"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -129,9 +120,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Request latency of Mediawiki Web Pod - Item"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -169,9 +157,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Request latency of Special Version"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -208,9 +193,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Count of \"down\" checks of Mediawiki API"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -248,9 +230,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Count of \"down\" checks of The platform API health endpoint"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -287,9 +266,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Count of \"down\" checks of Queryservice"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -327,9 +303,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Count of \"down\" checks of Mediawiki Web Pod - Item"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -366,9 +339,6 @@ resource "google_monitoring_dashboard" "uptime-latency" {
             widget = {
               title   = "Count of \"down\" checks of Mediawiki Web Pod - Special:Version"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"

--- a/tf/env/staging/workload-technical-metric.tf
+++ b/tf/env/staging/workload-technical-metric.tf
@@ -13,9 +13,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "logging/user/staging-site-request-count (filtered) by label.domain [SUM]"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -54,9 +51,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "Mediawiki - Max CPU limit utilization "
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -93,9 +87,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "Mediawiki - Max Memory limit utilization "
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -131,9 +122,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "API - Max CPU limit utilization"
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -170,9 +158,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "APi - Memory limit utilization "
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -208,9 +193,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "SQL/Redis/ElasticSearch/Queryservice - Max CPU limit utilization "
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"
@@ -247,9 +229,6 @@ resource "google_monitoring_dashboard" "workload-technical-metrics" {
             widget = {
               title   = "SQL/Redis/ElasticSearch/Queryservice - Max Memory Limit Utilization "
               xyChart = {
-                chartOptions      = {
-                  mode = "COLOR"
-                }
                 dataSets          = [
                   {
                     minAlignmentPeriod = "60s"


### PR DESCRIPTION
Starting 2023/07/20 some GCP Dashboards would start diffing dirty against main without any changes being made in the code. It seems this is due to API changes in GCP that stopped persisting this setting without raising errors or similar.

To work around this, remove all such settings.

Ticket: https://phabricator.wikimedia.org/T342525