### PR TITLE
chore(api): enable stackdriver for staging api

### DIFF
--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -23,6 +23,8 @@ wbstack:
 
 app:
   name: WBaaS Wikibase Dev
+  stackdriver:
+    enabled: true
   redis:
     prefix: wikibase_dev_api
   mail:


### PR DESCRIPTION
Testing what exactly happens if we turn this on
