### PR TITLE
Revert "chore(api): enable stackdriver for staging api (#1018)"

### DIFF
--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -23,8 +23,6 @@ wbstack:
 
 app:
   name: WBaaS Wikibase Dev
-  stackdriver:
-    enabled: true
   redis:
     prefix: wikibase_dev_api
   mail:


### PR DESCRIPTION
This reverts commit 734ccc71fdd05db089b7f4b8c52f259f30a24791.

The stackdriver configuration does not work as intended.

```
[2023-07-27 13:13:29][okJavaIVgc7oIuCEmSFa4Nma2B2KCa6X] Processing: App\Jobs\MediawikiInit

In RequestWrapper.php line 368:

   {
     "error": {
       "code": 403,
       "message": "Permission 'logging.logEntries.create' denied on resource (or it may not exist).",
       "status": "PERMISSION_DENIED",
       "details": [
         {
           "@type": "type.googleapis.com/google.rpc.ErrorInfo",
           "reason": "IAM_PERMISSION_DENIED",
           "domain": "iam.googleapis.com",
           "metadata": {
             "permission": "logging.logEntries.create"
           }
         }
       ]
     }
   }
```
