### PR TITLE
chore(stackdriver): enable stackdriver for error reporting only in staging

### DIFF
--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -20,6 +20,11 @@ wbstack:
     mail:
       recipient: contact.wikibase@wikimedia.de
       sender: contact-<subject>@wikibase.dev
+  stackdriver:
+    enabled: true
+    loggingEnabled: false
+    tracingEnabled: false
+    errorReportingEnabled: true
 
 app:
   name: WBaaS Wikibase Dev


### PR DESCRIPTION
#1018 did not disable logging, so we might want to try disabling everything but error reporting to see if this brings us what we want.