### PR TITLE
chore(error-reporting): enable stackdriver error reporting for production

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -114,8 +114,8 @@ app:
     serviceAccountSecret: api-serviceaccount
     existingSecret: api-passport-keys
   stackdriver:
-    enabled: false
-    loggingEnabled: true
+    enabled: true
+    loggingEnabled: false
     tracingEnabled: false
     errorReportingEnabled: true
 

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -35,8 +35,3 @@ app:
     smtpPasswordSecretKey: password
     smtphost: smtp.eu.mailgun.org
     smtpport: 587
-  stackdriver:
-    enabled: true
-    loggingEnabled: false
-    tracingEnabled: false
-    errorReportingEnabled: true


### PR DESCRIPTION
Right now, throttling of signup would not be reported anywhere as stackdriver is still disabled.