### PR TITLE
feat(cluster): update logging variant for staging

### DIFF
--- a/tf/env/staging/cluster.tf
+++ b/tf/env/staging/cluster.tf
@@ -48,7 +48,7 @@ resource "google_container_node_pool" "wbaas-2_large" {
             enable_integrity_monitoring = true
             enable_secure_boot          = false
         }
-
+        logging_variant = "MAX_THROUGHPUT"
     }
 
     upgrade_settings {


### PR DESCRIPTION
Our current suspicion is that log backpressure is currently causing the cluster nodes to run out of ephemeral storage. If so, changing logging configfuration to allow for higher throughput might help.

Mostly interested in doing this in staging first to find out whether this requires a node replacement or can be done on the running node.

Diffs against staging like this

```
Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:                                                                 
  ~ update in-place                                                                                                                                                                                        
                                                                                                                                                                                                           
Terraform will perform the following actions:                                                                                                                                                              
                                                                                                                                                                                                           
  # google_container_node_pool.wbaas-2_large will be updated in-place                                                                                                                                      
  ~ resource "google_container_node_pool" "wbaas-2_large" {                                                                                                                                                
        id                          = "projects/wikibase-cloud/locations/europe-west3-a/clusters/wbaas-2/nodePools/large-pool"                                                                             
        name                        = "large-pool"                                                                                                                                                         
        # (9 unchanged attributes hidden)                                                                                                                                                                  
                                                                                                                                                                                                           
      ~ node_config {                                                                                                                                                                                      
          ~ logging_variant   = "DEFAULT" -> "MAX_THROUGHPUT"                                                                                                                                              
            tags              = []                                                                                                                                                                         
            # (14 unchanged attributes hidden)                                                                                                                                                             
                                                                                                                                                                                                           
            # (1 unchanged block hidden)                                                                                                                                                                   
        }                                                                                                                                                                                                  
                                                                                                                                                                                                           
        # (2 unchanged blocks hidden)                                                                                                                                                                      
    }                                                                                                                                                                                                      
                                                                                                                                                                                                           
Plan: 0 to add, 1 to change, 0 to destroy.  
```