### PR TITLE
DNM: example: `asdf` for local tooling

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-kubectl 1.27.4
-minikube 1.31.1
-terraform 1.5.4
-helm 3.12.2
-helmfile 0.153.1
-skaffold 2.6.2
+kubectl 1.27.4 system
+minikube 1.31.1 system
+terraform 1.5.4 system
+helm 3.12.2 system
+helmfile 0.153.1 system
+skaffold 2.6.2 system

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,3 +4,4 @@ terraform 1.5.4 system
 helm 3.12.2 system
 helmfile 0.153.1 system
 skaffold 2.6.2 system
+gcloud 440.0.0 system

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,6 @@
+kubectl 1.27.4
+minikube 1.31.1
+terraform 1.5.4
+helm 3.12.2
+helmfile 0.153.1
+skaffold 2.6.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -5,3 +5,4 @@ helm 3.12.2 system
 helmfile 0.153.1 system
 skaffold 2.6.2 system
 gcloud 440.0.0 system
+yq 4.34.2 system

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ asdf-install: # @HELP Install the currently recommended versions of runtime tool
 asdf-install:
 	./bin/local/asdf-add-plugins.sh
 	asdf install
+	./bin/local/asdf-global-fallback.sh
 
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,11 @@ help:
 	        BEGIN {FS = ": *# *@HELP"};           \
 	        { printf "  %-20s %s\n", $$1, $$2 };  \
 	    '
+.PHONY: asdf-install
+asdf-install: # @HELP Install the currently recommended versions of runtime tools via asdf
+asdf-install:
+	./bin/local/asdf-add-plugins.sh
+	asdf install
 
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube

--- a/bin/local/asdf-add-plugins.sh
+++ b/bin/local/asdf-add-plugins.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+if [[ ! $(which asdf) ]]; then
+	echo "asdf is missing. Please install it according to the official documentation: https://asdf-vm.com/guide/getting-started.html#_3-install-asdf"
+	exit 1
+fi
+
+PLUGINS=$(cat .tool-versions | awk '{print $1}')
+
+for PLUGIN in ${PLUGINS}; do
+	#echo install.sh: Adding plugin "${PLUGIN}"
+	asdf plugin add "${PLUGIN}"
+done
+
+exit 0

--- a/bin/local/asdf-add-plugins.sh
+++ b/bin/local/asdf-add-plugins.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
 if [[ ! $(which asdf) ]]; then
-	echo "asdf is missing. Please install it according to the official documentation: https://asdf-vm.com/guide/getting-started.html#_3-install-asdf"
+	echo "asdf is missing. Please install it according to the official documentation: https://asdf-vm.com/guide/getting-started.html"
 	exit 1
 fi
 
 PLUGINS=$(cat .tool-versions | awk '{print $1}')
 
 for PLUGIN in ${PLUGINS}; do
-	#echo install.sh: Adding plugin "${PLUGIN}"
 	asdf plugin add "${PLUGIN}"
 done
 

--- a/bin/local/asdf-global-fallback.sh
+++ b/bin/local/asdf-global-fallback.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ ! $(which asdf) ]]; then
+	echo "asdf is missing. Please install it according to the official documentation: https://asdf-vm.com/guide/getting-started.html"
+	exit 1
+fi
+
+PLUGINS=$(cat .tool-versions | awk '{print $1}')
+
+for PLUGIN in ${PLUGINS}; do
+	asdf global "${PLUGIN}" system
+done
+
+exit 0


### PR DESCRIPTION
> **Do not merge**

This PR serves as an example of how we could make use of [asdf](https://asdf-vm.com/) as a way of keeping our local tooling in sync and up-to-date.

# `asdf`
> Extendable version manager with support for Ruby, Node.js, Elixir, Erlang & more 
## About
### Why?
We keep seeing troubles among engineers which are caused by outdated or different versions of our tooling. We could keep them in sync by using different solutions, `asdf` is one of them.

### My evaluation
#### Pros:
- installation and usage is fairly easy
  - as well as maintenance (hopefully :crossed_fingers: ) 
- it only applies to the `wbaas-deploy` tree: outside of that dir structure system fallbacks are used (e.g. the versions of the tools that you installed in some other way)
- it's entirely optional: even if you don't opt-in to use this, we could use the [.tool-versions](https://github.com/wmde/wbaas-deploy/pull/1030/files#diff-751af1a340658c7b8176fe32d7db9fadbe15d1d075daba1919a91df04155bc70) file as a way of documenting which versions we expect people are using

#### Cons:
- Yet another tool and complexity
  - my added bash scripts aren't ideal IMO  
- Reliance/dependance on community driven binary sources
- Even if the system fallbacks are used (e.g. you are outside the `wbaas-deploy` tree), asdf shims are getting called - potential error source?

### How to
- [Download](https://asdf-vm.com/guide/getting-started.html#_2-download-asdf) and [install](https://asdf-vm.com/guide/getting-started.html#_3-install-asdf) `asdf`
  - For example by
    - running `git clone https://github.com/asdf-vm/asdf.git ~/.asdf --branch v0.12.0`
    - and (for example) adding this to `~/.profile`:
```
export ASDF_DIR="$HOME/.asdf"
. "$HOME/.asdf/asdf.sh"
``` 
- Run `make asdf-install`, which does three things:
  - adding tool "plugins" (basically the package sources)
  - installs the tools with the current versions defined in `.tool-versions`
  - sets a system fallback for the tools outside of `wbaas-deploy` (this touches `~/.tool-versions`)  
- Run the tools (`helmfile version`, `minikube version`, etc.)
  - tip: `asdf which <toolname>` shows you which binary the shim is calling at the moment:
```
deer@C352 ~/wbaas/wbaas-deploy $ asdf which helmfile
/home/deer/.asdf/installs/helmfile/0.153.1/bin/helmfile
deer@C352 ~/wbaas/wbaas-deploy $ cd
deer@C352 ~ $ asdf which helmfile
/home/deer/.local/bin/helmfile
```