### PR TITLE
chore(staging): scale down to 3 bigger nodes

### DIFF
--- a/tf/env/staging/cluster.tf
+++ b/tf/env/staging/cluster.tf
@@ -23,14 +23,14 @@ resource "google_container_cluster" "wbaas-2" {
 resource "google_container_node_pool" "wbaas-2_large" {
     cluster = "wbaas-2"
     name                = "large-pool"
-    node_count          = 6
+    node_count          = 3
     node_locations      = [
         "europe-west3-a",
     ]
     node_config {
         disk_size_gb      = 32
         disk_type         = "pd-standard"
-        machine_type      = "n2-standard-4"
+        machine_type      = "n2-standard-8"
         metadata          = {
             "disable-legacy-endpoints" = "true"
         }


### PR DESCRIPTION
High Throughput logging uses 2 CPU per nodes, so let's try working around this by having 3 nodes twice as big.