### PR TITLE
chore(elasticsearch): lower cpu limits in staging

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
@@ -9,10 +9,10 @@ annotations:
 master:
   resources:
     requests:
-      cpu: "1"
+      cpu: "0.5"
       memory: "1Gi"
     limits:
-      cpu: "1"
+      cpu: "0.5"
       memory: "1Gi"
   persistence:
     enabled: true
@@ -23,10 +23,10 @@ master:
 data:
   resources:
     requests:
-      cpu: "2"
+      cpu: "1"
       memory: "4Gi"
     limits:
-      cpu: "2"
+      cpu: "1"
       memory: "4Gi"
   persistence:
     enabled: true
@@ -37,8 +37,8 @@ data:
 coordinating:
   resources:
     requests:
-      cpu: "1"
+      cpu: "0.5"
       memory: "1Gi"
     limits:
-      cpu: "1"
+      cpu: "0.5"
       memory: "1Gi"


### PR DESCRIPTION
Right now it's not possible to schedule all pods in staging.