### PR TITLE
chore(elasticsearch): allow more CPU usage for staging master

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
@@ -9,10 +9,10 @@ annotations:
 master:
   resources:
     requests:
-      cpu: "0.5"
+      cpu: "1"
       memory: "1Gi"
     limits:
-      cpu: "0.5"
+      cpu: "1"
       memory: "1Gi"
   persistence:
     enabled: true


### PR DESCRIPTION
As the cluster is currently unable to assemble, let's maybe try this?