### PR TITLE
local/staging: add prometheus-es-exporter for 7.10 cluster

### DIFF
--- a/k8s/helmfile/env/local/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
@@ -1,0 +1,7 @@
+resources:
+  requests:
+    cpu: 125m
+    memory: 156Mi
+  limits:
+    cpu: 125m
+    memory: 256Mi

--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
@@ -1,0 +1,23 @@
+es:
+  uri: http://elasticsearch-1.default.svc.cluster.local:9200
+  timeout: 90s
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 1.25Gi
+  limits:
+    cpu: 250m
+    memory: 2Gi
+
+serviceMonitor:
+  scrapeTimeout: 50s
+  interval: 60s
+  enabled: true
+  labels:
+    release: kube-prometheus-stack
+  metricRelabelings:
+    - sourceLabels: [cluster]
+      targetLabel: es_cluster
+    - regex: ^cluster$
+      action: labeldrop

--- a/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
@@ -1,0 +1,7 @@
+resources:
+  requests:
+    cpu: 250m
+    memory: 512Mi
+  limits:
+    cpu: 250m
+    memory: 512Mi

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -226,6 +226,13 @@ releases:
     version: 5.2.0
     <<: *default_release
 
+  - name: prometheus-elasticsearch-exporter-1
+    namespace: monitoring
+    chart: prometheus-community/prometheus-elasticsearch-exporter
+    installed: {{ ne .Environment.Name "production" | toYaml }}
+    version: 5.2.0
+    <<: *default_release
+
   - name: istio-service-mesh
     namespace: istio-system
     chart: ./../../charts/istio-service-mesh


### PR DESCRIPTION
Copies the existing exporter configuration. This targets the main elasticsearch service which only targets
the coordinating nodes.

Also add configuration with production values so that rolling forward to production will see minimal changes

After deploying this we need to follow up on the alerting and dashboards using ES metrics since we may now see places where data from both clusters are unintentionally mixed