### PR TITLE
chore(jobs): add ttl of 30 days to job templates

### DIFF
--- a/k8s/jobs/changeReplicationPasswordOnSecondary.yaml
+++ b/k8s/jobs/changeReplicationPasswordOnSecondary.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: change-replication-password-on-secondary
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/changeReplicationPasswordOnSecondary.yaml
+++ b/k8s/jobs/changeReplicationPasswordOnSecondary.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: change-replication-password-on-secondary
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/elasticSearchImportJob.yaml
+++ b/k8s/jobs/elasticSearchImportJob.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       name: load-elasticsearch-data
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: import-elasticsearch
           command:

--- a/k8s/jobs/elasticSearchImportJob.yaml
+++ b/k8s/jobs/elasticSearchImportJob.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       name: load-elasticsearch-data
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: import-elasticsearch
           command:

--- a/k8s/jobs/forceSearchIndexFrom.yaml
+++ b/k8s/jobs/forceSearchIndexFrom.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       name: force-search-index-from
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: force-search-index-from
           command:

--- a/k8s/jobs/forceSearchIndexFrom.yaml
+++ b/k8s/jobs/forceSearchIndexFrom.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       name: force-search-index-from
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: force-search-index-from
           command:

--- a/k8s/jobs/rebuildQuantityUnitsJob.yaml
+++ b/k8s/jobs/rebuildQuantityUnitsJob.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       name: rebuild-quantity-units
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: rebuild-quantity-units
           command:

--- a/k8s/jobs/rebuildQuantityUnitsJob.yaml
+++ b/k8s/jobs/rebuildQuantityUnitsJob.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       name: rebuild-quantity-units
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: rebuild-quantity-units
           command:

--- a/k8s/jobs/resetOtherSqlSecretsJob.yaml
+++ b/k8s/jobs/resetOtherSqlSecretsJob.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: reset-other-sql-secrets-job
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/resetOtherSqlSecretsJob.yaml
+++ b/k8s/jobs/resetOtherSqlSecretsJob.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: reset-other-sql-secrets-job
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/resetRootSqlSecretJob.yaml
+++ b/k8s/jobs/resetRootSqlSecretJob.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   template:
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: reset-root-sql-secret-job
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/resetRootSqlSecretJob.yaml
+++ b/k8s/jobs/resetRootSqlSecretJob.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   template:
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: reset-root-sql-secret-job
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/runAllMWJobsJob.yaml
+++ b/k8s/jobs/runAllMWJobsJob.yaml
@@ -7,7 +7,7 @@ spec:
     metadata:
       name: run-all-mw-jobs
     spec:
-      ttlSecondsAfterFinished: 18144000
+      ttlSecondsAfterFinished: 604800
       containers:
         - name: run-all-mw-jobs
           command:

--- a/k8s/jobs/runAllMWJobsJob.yaml
+++ b/k8s/jobs/runAllMWJobsJob.yaml
@@ -7,6 +7,7 @@ spec:
     metadata:
       name: run-all-mw-jobs
     spec:
+      ttlSecondsAfterFinished: 18144000
       containers:
         - name: run-all-mw-jobs
           command:


### PR DESCRIPTION
There are currently >300 job objects floating around in our prod cluster. Are there any downsides of setting a ttl to them? I went for 30 days here

https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/

As an alternative we could add a script or something that edits this into the spec of existing jobs, so we could also opt for "cleaning" whenever we feel like its too much, instead of specifying it in beforehand (this would also come in handy to get rid of the current pile of old completed jobs)


