### PR TITLE
feat(local): install minio object storage via helm chart

### DIFF
--- a/k8s/helmfile/env/local/minio.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/minio.values.yaml.gotmpl
@@ -1,0 +1,19 @@
+existingSecret: minio-credentials
+
+image:
+  tag: RELEASE.2023-07-07T07-13-57Z
+
+mode: standalone
+
+replicas: 1
+
+persistence:
+  size: 4Gi
+
+buckets:
+  - name: backups
+    policy: public
+
+resources:
+  requests:
+    memory: 0.5Gi

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -18,6 +18,8 @@ repositories:
     url: https://prometheus-community.github.io/helm-charts
   - name: istio
     url: https://istio-release.storage.googleapis.com/charts
+  - name: minio
+    url: https://charts.min.io
 
 environments:
   default:
@@ -257,3 +259,11 @@ releases:
     version: 5.0.1
     values:
       - env/local/mailhog.values.yaml.gotmpl
+
+  - name: minio
+    installed: {{ eq .Environment.Name "local" | toYaml }}
+    namespace: default
+    chart: minio/minio
+    version: 5.0.13
+    values:
+      - env/local/minio.values.yaml.gotmpl

--- a/tf/env/local/secrets-minio.tf
+++ b/tf/env/local/secrets-minio.tf
@@ -1,0 +1,17 @@
+resource "random_password" "minio-password" {
+  length = 32
+}
+
+resource "kubernetes_secret" "minio-credentials" {
+  metadata {
+    name = "minio-credentials"
+  }
+
+  binary_data = {
+    "rootPassword" = base64encode(random_password.minio-password.result)
+  }
+
+  data = {
+    "rootUser" = "minio"
+  }
+}


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T343112

This is prep work for moving backup transfer over to an S3 client. As of this PR, there are no consumers of the MinIO service.

## How to test/use this locally

1. Apply the changes and wait for the `minio` service to become ready
1. Install the [minio client](https://min.io/docs/minio/linux/reference/minio-mc.html)
1. Open a tunnel for the service:
    ```
    kubectl port-forward svc/minio 9000:9000
    ```
1. Set an alias for your local cluster
    ```
    mc alias set minikube "http://localhost:9000/" minio $(k get secrets/minio-credentials -o json | jq -r .data.rootPassword | base64 -d)
    ```
1. Poke around, e.g. create a new bucket and upload a file
   ```
   mc mb test-bucket
   echo "oh wow" > foo.txt
   mc cp foo.txt minikube/test-bucket
   mc cat minikube/test-bucket/foo.txt
   ```