### PR TITLE
refactor(jobs): add bash -v for verbosity

### DIFF
--- a/k8s/jobs/elasticSearchImportJob.yaml
+++ b/k8s/jobs/elasticSearchImportJob.yaml
@@ -11,7 +11,7 @@ spec:
         - name: import-elasticsearch
           command:
             - 'bash'
-            - '-c'
+            - '-cv'
             - >
               php artisan wbs-wiki:setSetting id $WIKI_ID wwExtEnableElasticSearch 1 &&
               php artisan job:dispatchNow CirrusSearch\\ElasticSearchIndexInit $WIKI_ID &&

--- a/k8s/jobs/forceSearchIndexFrom.yaml
+++ b/k8s/jobs/forceSearchIndexFrom.yaml
@@ -11,7 +11,7 @@ spec:
         - name: force-search-index-from
           command:
             - 'bash'
-            - '-c'
+            - '-cv'
             - >
                 MW_INSTALL_PATH=/var/www/html/w/
                 php

--- a/k8s/jobs/rebuildQuantityUnitsJob.yaml
+++ b/k8s/jobs/rebuildQuantityUnitsJob.yaml
@@ -11,7 +11,7 @@ spec:
         - name: rebuild-quantity-units
           command:
             - 'bash'
-            - '-c'
+            - '-cv'
             - >
                 MW_INSTALL_PATH=/var/www/html/w/
                 php

--- a/k8s/jobs/runAllMWJobsJob.yaml
+++ b/k8s/jobs/runAllMWJobsJob.yaml
@@ -11,7 +11,7 @@ spec:
         - name: run-all-mw-jobs
           command:
             - 'bash'
-            - '-c'
+            - '-cv'
             - |
                 JOBS_TO_GO=1
                 while [ "$JOBS_TO_GO" != "0" ]


### PR DESCRIPTION
This adds the bash flag `-v` for some verbosity to our k8s yaml job templates, so we can see when and what command actually runs.

From the manpage:
```
       -v        Print shell input lines as they are read.
```

I left the ones with SQL out because it would probably make them print passwords.
