### PR TITLE
k8s: Set 7.10 ES cluster name

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-1.values.yaml.gotmpl
@@ -49,3 +49,5 @@ coordinating:
 
 ingest:
   enabled: false
+
+clusterName: {{ .Release.Name }}


### PR DESCRIPTION
By setting this name to a custom value rather than the default we're able to more easily differentiate clusters in metrics etc.