### PR TITLE
chore(local): set api replica count to 1

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -53,3 +53,9 @@ external:
     secretName: recaptcha-v2-secrets
   recaptcha3:
     secretName: recaptcha-v3-secrets
+
+replicaCount:
+  web: 1
+  backend: 1
+  scheduler: 1
+  queue: 1


### PR DESCRIPTION
My suggestion is to keep replica counts low for the local environment if it's not strictly needed, in order to make debugging and looking at logs easier

