### PR TITLE
chore(local): set mediawiki replica count to 1

### DIFF
--- a/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
@@ -21,3 +21,9 @@ mw:
     sitekeySecretKey: site_key
     secretkeySecretName: recaptcha-v2-dev-secrets
     secretkeySecretKey: secret_key
+
+replicaCount:
+  backend: 1
+  web: 1
+  webapi: 1
+  alpha: 1


### PR DESCRIPTION
decreases mediawiki pod replicas to 1 for the local environment

See https://github.com/wmde/wbaas-deploy/pull/1093
