### PR TITLE
refactor(job): Add upper limit for forceSearchIndex

### DIFF
--- a/k8s/jobs/forceSearchIndexFromTo.sh
+++ b/k8s/jobs/forceSearchIndexFromTo.sh
@@ -1,6 +1,10 @@
 
 # WBS_FORCE_SEARCH_INDEX_FROM should be set to time to reindex from (exclusive) in YYYY-mm-ddTHH:mm:ssZ format
+# WBS_FORCE_SEARCH_INDEX_TO should be set to time to reindex to (exclusive) in YYYY-mm-ddTHH:mm:ssZ format
 # WBS_DOMAIN should be set to the domain to reindex
+
+WBS_FORCE_SEARCH_INDEX_FROM=${WBS_FORCE_SEARCH_INDEX_FROM:-1970-01-01T00:00:00Z}
+WBS_FORCE_SEARCH_INDEX_TO=${WBS_FORCE_SEARCH_INDEX_TO:-2042-00-00T00:00:00Z}
 
 tmp_file=$(mktemp --suffix=.json)
 
@@ -8,10 +12,11 @@ MW_POD=$(kubectl get pods --field-selector='status.phase=Running' -l app.kuberne
 MW_POD_JSON=$(kubectl get pods $MW_POD -o=json)
 echo ${MW_POD_JSON} > $tmp_file
 
-kubectl create -f forceSearchIndexFrom.yaml -o=json --dry-run=client |\
+kubectl create -f forceSearchIndexFromTo.yaml -o=json --dry-run=client |\
 jq -s ".[0].spec.template.spec.containers[0].image = .[1].spec.containers[0].image" - $tmp_file |\
 jq ".[0].spec.template.spec.containers[0].env = .[1].spec.containers[0].env" |\
 jq ".[0]" |\
 jq ".spec.template.spec.containers[0].env += [{\"name\": \"WBS_DOMAIN\", \"value\": \"${WBS_DOMAIN}\"}]" |\
 jq ".spec.template.spec.containers[0].env += [{\"name\": \"WBS_FORCE_SEARCH_INDEX_FROM\", \"value\": \"${WBS_FORCE_SEARCH_INDEX_FROM}\"}]" |\
+jq ".spec.template.spec.containers[0].env += [{\"name\": \"WBS_FORCE_SEARCH_INDEX_TO\", \"value\": \"${WBS_FORCE_SEARCH_INDEX_TO}\"}]"|\
 kubectl create -f -

--- a/k8s/jobs/forceSearchIndexFromTo.yaml
+++ b/k8s/jobs/forceSearchIndexFromTo.yaml
@@ -1,16 +1,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  generateName: force-search-index-from-
+  generateName: force-search-index-from-to-
   namespace: adhoc-jobs
 spec:
   ttlSecondsAfterFinished: 604800
   template:
     metadata:
-      name: force-search-index-from
+      name: force-search-index-from-to
     spec:
       containers:
-        - name: force-search-index-from
+        - name: force-search-index-from-to
           command:
             - 'bash'
             - '-c'
@@ -19,4 +19,5 @@ spec:
                 php
                 /var/www/html/w/extensions/CirrusSearch/maintenance/ForceSearchIndex.php
                 --from="${WBS_FORCE_SEARCH_INDEX_FROM}"
+                --to="${WBS_FORCE_SEARCH_INDEX_TO}"
       restartPolicy: Never


### PR DESCRIPTION
In favor of merging the copypasta script from #1081, I refactored the existing script to be able to use both the `--from` and `--to` options (only one of them works, as well as both, or none).


