### PR TITLE
fix(jobs): move `ttlSecondsAfterFinished`

### DIFF
--- a/k8s/jobs/changeReplicationPasswordOnSecondary.yaml
+++ b/k8s/jobs/changeReplicationPasswordOnSecondary.yaml
@@ -4,10 +4,9 @@ metadata:
   generateName: change-replication-password-on-secondary-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: change-replication-password-on-secondary
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/elasticSearchImportJob.yaml
+++ b/k8s/jobs/elasticSearchImportJob.yaml
@@ -4,12 +4,11 @@ metadata:
   generateName: load-elasticsearch-data-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     metadata:
       name: load-elasticsearch-data
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: import-elasticsearch
           command:

--- a/k8s/jobs/elasticSearchInitJob.yaml
+++ b/k8s/jobs/elasticSearchInitJob.yaml
@@ -4,8 +4,8 @@ metadata:
   generateName: elasticsearch-init-job-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     metadata:
       name: elasticsearch-init-job
     spec:

--- a/k8s/jobs/forceSearchIndexFrom.yaml
+++ b/k8s/jobs/forceSearchIndexFrom.yaml
@@ -4,12 +4,11 @@ metadata:
   generateName: force-search-index-from-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     metadata:
       name: force-search-index-from
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: force-search-index-from
           command:

--- a/k8s/jobs/rebuildQuantityUnitsJob.yaml
+++ b/k8s/jobs/rebuildQuantityUnitsJob.yaml
@@ -4,12 +4,11 @@ metadata:
   generateName: rebuild-quantity-units-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     metadata:
       name: rebuild-quantity-units
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: rebuild-quantity-units
           command:

--- a/k8s/jobs/resetOtherSqlSecretsJob.yaml
+++ b/k8s/jobs/resetOtherSqlSecretsJob.yaml
@@ -4,10 +4,9 @@ metadata:
   generateName: reset-other-sql-secrets-job-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: reset-other-sql-secrets-job
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/resetRootSqlSecretJob.yaml
+++ b/k8s/jobs/resetRootSqlSecretJob.yaml
@@ -4,10 +4,9 @@ metadata:
   generateName: reset-root-sql-secret-job-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: reset-root-sql-secret-job
           image: docker.io/bitnami/mariadb:10.5.15-debian-10-r52

--- a/k8s/jobs/runAllMWJobsJob.yaml
+++ b/k8s/jobs/runAllMWJobsJob.yaml
@@ -4,12 +4,11 @@ metadata:
   generateName: run-all-mw-jobs-
   namespace: adhoc-jobs
 spec:
+  ttlSecondsAfterFinished: 604800
   template:
-    ttlSecondsAfterFinished: 604800
     metadata:
       name: run-all-mw-jobs
     spec:
-      ttlSecondsAfterFinished: 604800
       containers:
         - name: run-all-mw-jobs
           command:


### PR DESCRIPTION
Not sure what happened to these yaml files but `ttlSecondsAfterFinished` needs to be in `.spec`

