### PR TITLE
tf:both fix platform summary error

### DIFF
--- a/tf/env/production/platform-summary-dashboard.tf
+++ b/tf/env/production/platform-summary-dashboard.tf
@@ -223,6 +223,7 @@ resource "google_monitoring_dashboard" "platform-summary" {
                                     number of users created in the last 24 hours
                                 EOT
                 format  = "MARKDOWN"
+                style = {}
               }
               title = "Legend"
             }

--- a/tf/env/staging/platform-summary-dashboard.tf
+++ b/tf/env/staging/platform-summary-dashboard.tf
@@ -223,6 +223,7 @@ resource "google_monitoring_dashboard" "platform-summary" {
                                     number of users created in the last 24 hours
                                 EOT
                 format  = "MARKDOWN"
+                style = {}
               }
               title = "Legend"
             }


### PR DESCRIPTION
It appears that the time time we stored our dashboard the json represention of the dashboard did not return a style object for text objects[0]. Now it always
returns empty ones.

This patch therefore adds them to avoid the perpetual-diff situation.

This patch should be a no-op on application and should remove TF perma-diff

[0] https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards#text