### PR TITLE
chore(staging): temporarily increase scratch disk size for backup

### DIFF
--- a/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
@@ -1,7 +1,7 @@
 image:
   tag: v0.3.0
 
-scratchDiskSpace: 8Gi
+scratchDiskSpace: 64Gi
 
 storage:
   bucketName: wikibase-dev-sql-backup


### PR DESCRIPTION
This should be helpful for debugging why #1092 fails