### PR TITLE
Revert "chore(mediawiki): test fallback by disconnecting Elasticsearch on staging"

### DIFF
--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -6,9 +6,6 @@ mw:
     allowedProxyCidr: "10.112.0.0/14"
   mail:
     domain: "wikibase.dev"
-  elasticsearch:
-    host: 127.0.0.1
-    port: 9200
 
 resources:
   web:


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1126