### PR TITLE
deploy(local/staging): api 8x.22.1

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.22.0
+  tag: 8x.22.1
 
 ingress:
   tls: null
@@ -20,6 +20,7 @@ wbstack:
 
 app:
   name: WBaaS Localhost
+  env: local
   logLevel: debug
   redis:
     prefix: wikibase_dev_api

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -64,6 +64,8 @@ wbstack:
 
 app:
   name: WBaaS Wikibase Production
+  env: production
+  logLevel: info
   keySecretName: api-app-secrets
   keySecretKey: api-app-key
   url: {{ .Values.services.app.url }}

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.22.0
+  tag: 8x.22.1
 
 ingress:
   tls:
@@ -23,6 +23,7 @@ wbstack:
 
 app:
   name: WBaaS Wikibase Dev
+  env: staging
   logLevel: info
   redis:
     prefix: wikibase_dev_api

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -150,7 +150,7 @@ releases:
 
   - name: api
     chart: wbstack/api
-    version: {{ ternary "0.26.0" "0.25.0" (ne .Environment.Name "production") }}
+    version: {{ ternary "0.26.1" "0.25.0" (ne .Environment.Name "production") }}
     namespace: default
     <<: *default_release
 


### PR DESCRIPTION
depends on: https://github.com/wbstack/api/pull/642
depends on: https://github.com/wbstack/charts/pull/127

This deploys API image 8x.22.1 via Chart 0.26.1

- the API image fixes recpatcha config https://github.com/wbstack/api/pull/642
- the new chart & values make use of the log level & app env settings

