### PR TITLE
chore(cleanup): recaptcha values

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -36,20 +36,13 @@ app:
     smtpPasswordSecretKey: password
   recaptcha:
     minScore: 0.5
-    secretSecretName: recaptcha-v3-dev-secrets
+    secretSecretName: {{ .Values.external.recaptcha3.secretName }}
     secretSecretKey: secret_key
   # TODO is this needed for local?
   gce:
     serviceAccountSecret: null
   stackdriver:
     enabled: false
-external:
-  letsencrypt:
-    email: thomas.arrow@wikimedia.de
-  recaptcha2:
-    secretName: recaptcha-v2-secrets
-  recaptcha3:
-    secretName: recaptcha-v3-secrets
 
 replicaCount:
   web: 1

--- a/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
@@ -17,9 +17,9 @@ mw:
     smtpUserSecretName: null
     smtpPasswordSecretName: null
   recaptcha:
-    sitekeySecretName: recaptcha-v2-dev-secrets
+    sitekeySecretName: {{ .Values.external.recaptcha2.secretName }}
     sitekeySecretKey: site_key
-    secretkeySecretName: recaptcha-v2-dev-secrets
+    secretkeySecretName: {{ .Values.external.recaptcha2.secretName }}
     secretkeySecretKey: secret_key
 
 replicaCount:

--- a/k8s/helmfile/env/local/ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ui.values.yaml.gotmpl
@@ -2,7 +2,7 @@ image:
   tag: sha-9a37f40
 
 ui:
-  recaptchaSitekeySecretName: recaptcha-v3-dev-secrets
+  recaptchaSitekeySecretName: {{ .Values.external.recaptcha3.secretName }}
   recaptchaSitekeySecretKey: site_key
 
 ingress:

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -106,8 +106,6 @@ app:
     smtphost: smtp.eu.mailgun.org
     smtpport: 587
   recaptcha:
-    sitekeySecretName: {{ .Values.external.recaptcha3.secretName }}
-    sitekeySecretKey: site_key
     secretSecretName: {{ .Values.external.recaptcha3.secretName }}
     secretSecretKey: secret_key
     badgehide: true

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -39,7 +39,7 @@ app:
     smtpport: 587
   recaptcha:
     minScore: 0.5
-    secretSecretName: recaptcha-v3-secrets
+    secretSecretName: {{ .Values.external.recaptcha3.secretName }}
     secretSecretKey: secret_key
 
 trustedProxy:

--- a/tf/env/local/secrets-recaptcha.tf
+++ b/tf/env/local/secrets-recaptcha.tf
@@ -1,7 +1,7 @@
-resource "kubernetes_secret" "recaptcha-v3-dev-secrets" {
+resource "kubernetes_secret" "recaptcha-v3-secrets" {
   for_each = toset(["default", "api-jobs", "adhoc-jobs"])
   metadata {
-    name = "recaptcha-v3-dev-secrets"
+    name = "recaptcha-v3-secrets"
     # default as staging
     namespace = each.value
   }
@@ -17,10 +17,10 @@ moved {
   to   = kubernetes_secret.recaptcha-v3-dev-secrets["default"]
 }
 
-resource "kubernetes_secret" "recaptcha-v2-dev-secrets" {
+resource "kubernetes_secret" "recaptcha-v2-secrets" {
   for_each = toset(["default", "api-jobs", "adhoc-jobs"])
   metadata {
-    name = "recaptcha-v2-dev-secrets"
+    name = "recaptcha-v2-secrets"
     # default as staging
     namespace = each.value
   }


### PR DESCRIPTION
This PR cleans up some value files
  - prod: api: `sitekeySecretName` gets removed (only UI needs it)
  - local & staging: api: recaptcha3 secret secret name gets read from private.yaml 
  - local: `external` block from api.values gets removed - honestly idk why it was even there
  - local: ui: recaptcha3 site secret name gets read from private.yaml
  - local: mw: recaptcha2 secrets name gets read from private.yaml
  - local: rename recaptcha secrets to match staging/prod (`recaptcha-vN-secrets` vs `recaptcha-vN-dev-secrets`)
    - **this will require to update your tfvars files**