### PR TITLE
Revert "chore(prod): increase disk size (ephemeral storage) (#1179)"

### DIFF
--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -31,7 +31,7 @@ resource "google_container_node_pool" "wbaas-3_highmem-16" {
     "europe-west3-a",
   ]
   node_config {
-    disk_size_gb = 100
+    disk_size_gb = 64
     disk_type    = "pd-standard"
     machine_type = "n2-highmem-16"
     metadata = {


### PR DESCRIPTION
This reverts commit 97eae65c3e0ebdc57b790a9b93a019068733e235.

Reverting because applying this will cause node replacements, which shall be discussed first.
