### PR TITLE
chore(prod): increase scratch volume size for backups

### DIFF
--- a/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
@@ -6,7 +6,7 @@ image:
 job:
   cronSchedule: "0 0 * * *"
 
-scratchDiskSpace: 64Gi
+scratchDiskSpace: 128Gi
 
 storage:
   bucketName: wikibase-cloud-sql-backup


### PR DESCRIPTION
https://phabricator.wikimedia.org/T348148

Presumably increasing node disk size is not needed (#1179) for the backups but rather the size of the backup scratch volume.
