### PR TITLE
chore(es6): increase timeout for cluster info update job

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch.values.yaml.gotmpl
@@ -40,3 +40,5 @@ esConfig:
 
     # T309378
     action.auto_create_index: false
+
+    cluster.info.update.timeout: 20s


### PR DESCRIPTION
Starting tonight, ElasticSearch logs are spammed with messages like:

```
[2023-10-09T20:58:49,729][WARN ][o.e.c.InternalClusterInfoService] [elasticsearch-master-0] Failed to update shard information for ClusterInfoUpdateJob within 15s timeout
```

---

This change is already applied using the HTTP API in both staging and production where it seems to work as intended (no more warnings).
