### PR TITLE
chore(deploy): production: tf-module-monitoring-20

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -1,5 +1,5 @@
 module "production-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-18"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-20"
 
   providers = {
     kubernetes = kubernetes.wbaas-3

--- a/tf/env/staging/monitoring.tf
+++ b/tf/env/staging/monitoring.tf
@@ -1,5 +1,5 @@
 module "staging-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-19"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-20"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }


### PR DESCRIPTION
Deploys tf monitoring module v20 to production. Note: v19 was never deployed before this.

PR of v20: https://github.com/wmde/wbaas-deploy/pull/1185
