### PR TITLE
chore(sql): raise configuration values for open table caches

### DIFF
--- a/k8s/helmfile/env/local/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/sql.values.yaml.gotmpl
@@ -43,6 +43,10 @@ primary:
     # 100MB, default & bitnami was 1GB (1073741824)
     max_binlog_size=107374182
 
+    # T348842
+    table_open_cache=4096
+    table_definition_cache=4096
+
     [mysql]
     # https://forums.mysql.com/read.php?103,189835,192421#msg-192421
     default-character-set=UTF8

--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -46,6 +46,10 @@ primary:
     # 100MB, default & bitnami was 1GB (1073741824)
     max_binlog_size=107374182
 
+    # T348842
+    table_open_cache=4096
+    table_definition_cache=4096
+
     [mysql]
     # https://forums.mysql.com/read.php?103,189835,192421#msg-192421
     default-character-set=UTF8

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -36,6 +36,10 @@ primary:
     # 100MB, default & bitnami was 1GB (1073741824)
     max_binlog_size=107374182
 
+    # T348842
+    table_open_cache=4096
+    table_definition_cache=4096
+
     [mysql]
     # https://forums.mysql.com/read.php?103,189835,192421#msg-192421
     default-character-set=UTF8


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T348842

These values are currently set manually in production where the job now passes again.