### PR TITLE
prod: reduce adhoc job parallelism

### DIFF
--- a/tf/env/production/namespaces.tf
+++ b/tf/env/production/namespaces.tf
@@ -39,7 +39,7 @@ resource "kubernetes_resource_quota" "adhoc-jobs-podquota" {
   }
   spec {
     hard = {
-      pods = 8
+      pods = 4
     }
     scopes = ["BestEffort"]
   }


### PR DESCRIPTION
Reducing these jobs since we seem to be seeing failures due to cluster timeouts