### PR TITLE
Increase elasticsearch-1 master liveness tolerance

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-1.values.yaml.gotmpl
@@ -25,7 +25,7 @@ master:
     storageClass: "premium-rwo"
     size: 5Gi
   livenessProbe:
-    initialDelaySeconds: 600
+    initialDelaySeconds: 1200
   readinessProbe:
     initialDelaySeconds: 600
 


### PR DESCRIPTION
These nodes are failing to start and eventually being killed due to failing the liveness checks. This attempts to increase that number in the hope they eventually become live.