### PR TITLE
Increase elasticsearch-1 master liveness and readiness

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-1.values.yaml.gotmpl
@@ -25,9 +25,9 @@ master:
     storageClass: "premium-rwo"
     size: 5Gi
   livenessProbe:
-    initialDelaySeconds: 1200
+    initialDelaySeconds: 1800
   readinessProbe:
-    initialDelaySeconds: 600
+    initialDelaySeconds: 1800
 
 data:
   heapSize: 32768m


### PR DESCRIPTION
We're still seeing these pods killed before they become ready.

Let's try bumping both values this time. Since we observed `transport not ready yet to handle incoming requests` perhaps the readiness probes themselves are impacting the time to live.