### PR TITLE
Keep staging elasticsearch-1 probes constant

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-1.values.yaml.gotmpl
@@ -20,6 +20,10 @@ master:
     accessModes: [ "ReadWriteOnce" ]
     storageClass: "premium-rwo"
     size: 5Gi
+  livenessProbe:
+    initialDelaySeconds: 1800
+  readinessProbe:
+    initialDelaySeconds: 1800
 
 data:
   heapSize: 4096m
@@ -35,6 +39,10 @@ data:
     accessModes: [ "ReadWriteOnce" ]
     storageClass: "premium-rwo"
     size: 10Gi
+  livenessProbe:
+    initialDelaySeconds: 600
+  readinessProbe:
+    initialDelaySeconds: 600
 
 coordinating:
   heapSize: 512m
@@ -45,3 +53,7 @@ coordinating:
     limits:
       cpu: "0.5"
       memory: "1Gi"
+  livenessProbe:
+    initialDelaySeconds: 600
+  readinessProbe:
+    initialDelaySeconds: 600


### PR DESCRIPTION
These appear to have been inadvertantly changed
due to the cascading change from production.

This commit fixes them at their current value