### PR TITLE
Revert "Staging+Local: Deploy new Platform API image 8x.25.3"

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.25.3
+  tag: 8x.25.2
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.25.3
+  tag: 8x.25.2
 
 ingress:
   tls:


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1213

Looks like this doesn't work with the updater:
```
Exception in thread "main" java.lang.IllegalStateException: Not a JSON Array: {"done":1,"eventFrom":632,"eventTo":633,"wiki_id":3,"entityIds":"Q7","updated_at":"2023-10-25T10:27:59.000000Z","created_at":"2023-10-25T10:27:59.000000Z","id":454,"wiki":{"id":3,"domain":"coffeebase.wikibase.dev","sitename":"coffeebase","deleted_at":null,"created_at":"2021-10-28T08:47:19.000000Z","updated_at":"2021-10-28T08:47:19.000000Z","description":null,"is_featured":0,"domain_decoded":"coffeebase.wikibase.dev","wiki_queryservice_namespace":{"id":3,"namespace":"qsns_610dc83f45","backend":"queryservice.default.svc.cluster.local:9999","wiki_id":3,"created_at":"2021-10-27T15:26:38.000000Z","updated_at":"2021-10-27T15:26:38.000000Z"}}}
```

see also https://console.cloud.google.com/errors/detail/CMbG0_fayJO3pgE;time=P30D?project=wikibase-cloud&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error