### PR TITLE
fix(local): change variable declaration for recaptcha secrets

### DIFF
--- a/tf/env/local/secrets-recaptcha.tf
+++ b/tf/env/local/secrets-recaptcha.tf
@@ -7,8 +7,8 @@ resource "kubernetes_secret" "recaptcha-v3-secrets" {
   }
 
   data = {
-    "site_key"   = var.recaptcha_v3_dev_site_key,
-    "secret_key" = var.recaptcha_v3_dev_secret
+    "site_key"   = var.recaptcha_v3_site_key,
+    "secret_key" = var.recaptcha_v3_secret
   }
 }
 
@@ -26,8 +26,8 @@ resource "kubernetes_secret" "recaptcha-v2-secrets" {
   }
 
   data = {
-    "site_key"   = var.recaptcha_v2_dev_site_key,
-    "secret_key" = var.recaptcha_v2_dev_secret
+    "site_key"   = var.recaptcha_v2_site_key,
+    "secret_key" = var.recaptcha_v2_secret
   }
 }
 

--- a/tf/env/local/variables.tf
+++ b/tf/env/local/variables.tf
@@ -10,24 +10,24 @@ variable "sql-passwords" {
   ]
 }
 
-variable "recaptcha_v3_dev_site_key" {
+variable "recaptcha_v3_site_key" {
   type        = string
   description = "Site key to access recaptcha v3"
   sensitive   = true
 }
 
-variable "recaptcha_v3_dev_secret" {
+variable "recaptcha_v3_secret" {
   type        = string
   description = "Secret key to access recaptcha v3"
   sensitive   = true
 }
-variable "recaptcha_v2_dev_site_key" {
+variable "recaptcha_v2_site_key" {
   type        = string
   description = "Site key to access recaptcha v2"
   sensitive   = true
 }
 
-variable "recaptcha_v2_dev_secret" {
+variable "recaptcha_v2_secret" {
   type        = string
   description = "Secret key to access recaptcha v2"
   sensitive   = true


### PR DESCRIPTION
Starting today, my local dev env would prompt for values like `recaptcha_v3_dev_site_key` which seem to have been replaced by `recaptcha_v3_site_key` equivalents quite a while ago.