### PR TITLE
chore(mw): raise memory requests, lower number of replicas

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -3,7 +3,7 @@ image:
 
 replicaCount:
   backend: 2
-  web: 3
+  web: 2
   webapi: 2
   alpha: 1
 
@@ -53,7 +53,7 @@ resources:
   web:
     requests:
       cpu: 150m
-      memory: 350Mi
+      memory: 1200Mi
     limits:
       cpu: 400m
       memory: 2000Mi


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T349887

Raising the requests for the pods lowers the chances of them being evicted by memory pressure on the host node.

Lowering the number of replicas again might help with reducing the number of DB connections being openend simultaneously.