### PR TITLE
chore(qs-updater): increase jvm heap size

### DIFF
--- a/k8s/helmfile/env/local/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice-updater.values.yaml.gotmpl
@@ -1,1 +1,2 @@
-# local resembles production so this file is empty
+app:
+  extraJvmOpts: "-XshowSettings:vm -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -Xms15m -Xmx30m -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=30m"

--- a/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
@@ -9,6 +9,7 @@ app:
   loopLimit: 100
   getBatchesEndpoint: http://api-app-backend.default.svc.cluster.local/backend/qs/getBatches
   wikibaseScheme: http
+  extraJvmOpts: "-XshowSettings:vm -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -Xms64m -Xmx128m -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=30m"
 
 resources:
   requests:

--- a/k8s/helmfile/env/staging/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice-updater.values.yaml.gotmpl
@@ -1,1 +1,2 @@
-# staging resembles production so this file is empty
+app:
+  extraJvmOpts: "-XshowSettings:vm -XX:+UseContainerSupport -XX:+ExitOnOutOfMemoryError -Xms15m -Xmx30m -XX:MetaspaceSize=20m -XX:MaxMetaspaceSize=30m"

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -187,7 +187,7 @@ releases:
   - name: queryservice-updater
     namespace: default
     chart: wbstack/queryservice-updater
-    version: 0.1.2
+    version: 0.2.0
     <<: *default_release
 
   - name: tool-cradle


### PR DESCRIPTION
This increased the allocated heap size used by the JVM in production only.

I followed the pattern used in ElasticSearch where the heap size is 50% of the memory that is generally available.