### PR TITLE
chore(mediawiki): allocate more RAM and CPU for mediawiki web

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -52,11 +52,11 @@ mw:
 resources:
   web:
     requests:
-      cpu: 150m
-      memory: 1200Mi
+      cpu: 500m
+      memory: 1600Mi
     limits:
-      cpu: 400m
-      memory: 2000Mi
+      cpu: '1'
+      memory: 2800Mi
   webapi:
     requests:
       cpu: 200m


### PR DESCRIPTION
Seems we can still crash using the current config, so let's see if MediaWiki is just hungry.