### PR TITLE
tf-module-monitoring-22: improve sql backup alerting

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-monitoring-22
+- Improve logical SQL backup alerting policy (alignment period 60s -> 1h)
+
 # tf-module-monitoring-21
 - Attempt to fix the failed logical SQL backup alerting policy
 

--- a/tf/modules/monitoring/sql-backup-failure-alert.tf
+++ b/tf/modules/monitoring/sql-backup-failure-alert.tf
@@ -28,7 +28,7 @@ resource "google_monitoring_alert_policy" "alert_policy_sql_logical_backup_failu
       aggregations {
         cross_series_reducer = "REDUCE_COUNT"
         per_series_aligner   = "ALIGN_COUNT"
-        alignment_period     = "60s"
+        alignment_period     = "3600s"
         group_by_fields = [
           "resource.labels.container_name",
         ]


### PR DESCRIPTION
https://phabricator.wikimedia.org/T349817#9334181

increasing the alignment period of the logical sql backup alerting from 60s to 1h (current max) in order to prevent false alarms

