### PR TITLE
Revert "Staging+Local: Deploy new Platform API image 8x.27.0"

### DIFF
--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.27.0
+  tag: 8x.26.0
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 8x.27.0
+  tag: 8x.26.0
 
 ingress:
   tls:


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1271

Looks like the code has a issue when WikiLifecycleEvents are missing:
```
[2023-11-17 11:39:00] staging.ERROR: Failure processing wiki então.carolinadoran.co for EmptyWikiNotification check: Trying to get property 'first_edited' of non-object                                                                   
[2023-11-17 11:39:00] staging.ERROR: Executing Job '' failed. {"exception":"[object] (Exception(code: 1): Executing Job '' failed. at /var/www/html/app/Providers/AppServiceProvider.php:32)                                               
[stacktrace]                                                                                                                                                                                                                               
#0 /var/www/html/vendor/laravel/framework/src/Illuminate/Events/Dispatcher.php(404): App\\Providers\\AppServiceProvider->App\\Providers\\{closure}(Object(Illuminate\\Queue\\Events\\JobFailed))   
```