### PR TITLE
chore(api): allocate more resources to queue pods

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -142,11 +142,11 @@ resources:
       memory: 400Mi
   queue:
     requests:
-      cpu: 1m
-      memory: 29Mi
+      cpu: 100m
+      memory: 256Mi
     limits:
-      cpu: 50m
-      memory: 100Mi
+      cpu: 250m
+      memory: 512Mi
   scheduler:
     requests:
       cpu: 5m


### PR DESCRIPTION
The CreateQueryserviceBatches job is now being OOM killed.