### PR TITLE
chore: update queryservice-updater image to latest version

### DIFF
--- a/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
@@ -3,7 +3,7 @@ replicaCount: 3
 image:
   repository: ghcr.io/wbstack/queryservice-updater
   pullPolicy: Always
-  tag: 0.3.84_3.11
+  tag: 0.3.84_3.12
 
 app:
   sleepTime: 5


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T352656

This should have no effects on the currently running setup and will just allow us to spawn K8s jobs that are based on the image at some point.