### PR TITLE
attempt to fix sql logical backup alerting policy

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-monitoring-23
+- Attempt to fix logical SQL backup alerting policy (alignment period 1h -> 15m)
+
 # tf-module-monitoring-22
 - Improve logical SQL backup alerting policy (alignment period 60s -> 1h)
 

--- a/tf/modules/monitoring/sql-backup-failure-alert.tf
+++ b/tf/modules/monitoring/sql-backup-failure-alert.tf
@@ -28,7 +28,7 @@ resource "google_monitoring_alert_policy" "alert_policy_sql_logical_backup_failu
       aggregations {
         cross_series_reducer = "REDUCE_COUNT"
         per_series_aligner   = "ALIGN_COUNT"
-        alignment_period     = "3600s"
+        alignment_period     = "900s"
         group_by_fields = [
           "resource.labels.container_name",
         ]


### PR DESCRIPTION
https://phabricator.wikimedia.org/T349817

release of `tf-module-monitoring-23`

Attempt to fix the alerting policy for sql logical backups. We suspect that the 1h alignment period is problematic as in combination with the absent trigger time it exceeds 24h 30m, which is maybe why it is not working.

