### PR TITLE
Test SQL alerting policy

### DIFF
--- a/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
@@ -4,7 +4,7 @@ image:
   pullPolicy: Always
 
 job:
-  cronSchedule: "0 0 * * *"
+  cronSchedule: "0 0 1 11 0"
 
 scratchDiskSpace: 128Gi
 

--- a/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
@@ -1,9 +1,6 @@
 image:
   tag: v0.3.1
 
-job:
-  cronSchedule: "0 0 1 11 0"
-
 scratchDiskSpace: 64Gi
 
 storage:

--- a/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/wbaas-backup.values.yaml.gotmpl
@@ -1,6 +1,9 @@
 image:
   tag: v0.3.1
 
+job:
+  cronSchedule: "0 0 1 11 0"
+
 scratchDiskSpace: 64Gi
 
 storage:

--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -1,5 +1,5 @@
 module "production-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-22"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-23"
 
   providers = {
     kubernetes = kubernetes.wbaas-3

--- a/tf/env/staging/monitoring.tf
+++ b/tf/env/staging/monitoring.tf
@@ -1,5 +1,5 @@
 module "staging-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-22"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-23"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T349817

**This PR needs to be reverted after testing** 

The purpose of this is to "disable" the sql backup cronjobs by using only a single date in November. We want to see if the change of the alerting policy in #1323 fixes it (this way we can test staging and prod at the same time since we saw strange differences here in the past).

- use `tf-module-monitoring-23` on staging and prod
- "disable" the backup cronjob for staging and prod
