### PR TITLE
Re-Enable SQL backups

### DIFF
--- a/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
@@ -4,7 +4,7 @@ image:
   pullPolicy: Always
 
 job:
-  cronSchedule: "0 0 1 11 0"
+  cronSchedule: "0 0 * * *"
 
 scratchDiskSpace: 128Gi
 


### PR DESCRIPTION
https://phabricator.wikimedia.org/T349817

The test of `tf-monitoring-23` was successful:
- [Incident on staging](https://console.cloud.google.com/monitoring/alerting/incidents/0.n5swu2bvw2kl?project=wikibase-cloud&pageState=(%22interval%22:(%22d%22:%22P1D%22,%22i%22:(%22s%22:%222023-12-14T23:34:08.000Z%22,%22e%22:%222023-12-15T08:32:54.837Z%22)))) 
- [Incident on production](https://console.cloud.google.com/monitoring/alerting/incidents/0.n5sz53jpj76e?project=wikibase-cloud&pageState=(%22interval%22:(%22d%22:%22P1D%22,%22i%22:(%22s%22:%222023-12-15T01:15:08.000Z%22,%22e%22:%222023-12-15T08:32:54.790Z%22))))

This PR re-enables the cronjob schedules and keeps the new module in use.
