### PR TITLE
fix(tf-monitoring): k8s labels for api queue have changed

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-monitoring-24
+- Fix log group lookup for platform summary dashboard
+
 # tf-module-monitoring-23
 - Attempt to fix logical SQL backup alerting policy (alignment period 1h -> 15m)
 

--- a/tf/modules/monitoring/platform-summary.tf
+++ b/tf/modules/monitoring/platform-summary.tf
@@ -5,7 +5,7 @@ resource "google_logging_metric" "platform-summary-metrics" {
         resource.type="k8s_container"
         resource.labels.cluster_name="${var.cluster_name}"
         resource.labels.namespace_name="default"
-        labels.k8s-pod/app_kubernetes_io/component="queue"
+        labels.k8s-pod/app_kubernetes_io/component="queue-default"
         labels.k8s-pod/app_kubernetes_io/instance="api"
         labels.k8s-pod/app_kubernetes_io/name="api" severity>=DEFAULT
         jsonPayload.platform_summary_version="v1"


### PR DESCRIPTION
Platform stats went missing since shipping #1329 as the deployment objects now have different labels, and the query in this module would yield no results.