### PR TITLE
chore(tf): bump monitoring module to v24

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -1,5 +1,5 @@
 module "production-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-23"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-24"
 
   providers = {
     kubernetes = kubernetes.wbaas-3

--- a/tf/env/staging/monitoring.tf
+++ b/tf/env/staging/monitoring.tf
@@ -1,5 +1,5 @@
 module "staging-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-23"
+  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-24"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }


### PR DESCRIPTION
Applies the changes from https://github.com/wmde/wbaas-deploy/pull/1332 to staging and production.