### PR TITLE
production: Enable Elasticsearch Prometheus Exporter

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -224,7 +224,6 @@ releases:
   - name: prometheus-elasticsearch-exporter-1
     namespace: monitoring
     chart: prometheus-community/prometheus-elasticsearch-exporter
-    installed: {{ ne .Environment.Name "production" | toYaml }}
     version: 5.2.0
     <<: *default_release
 


### PR DESCRIPTION
Looks like when we moved to the new cluster we accidentally overlooked this. It's useful to have in order to diagnose issues and monitor the cluster.

Bug: T354048