### PR TITLE
production: increase ES Prometheus exporter memory

### DIFF
--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
@@ -5,10 +5,10 @@ es:
 resources:
   requests:
     cpu: 250m
-    memory: 1.25Gi
+    memory: 2Gi
   limits:
     cpu: 250m
-    memory: 2Gi
+    memory: 4Gi
 
 serviceMonitor:
   scrapeTimeout: 50s


### PR DESCRIPTION
The exporter is currently being killed due to lack of memory let us try increasing this