### PR TITLE
production: bump ES Prom Exporter limits

### DIFF
--- a/k8s/helmfile/env/production/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/prometheus-elasticsearch-exporter-1.values.yaml.gotmpl
@@ -5,10 +5,10 @@ es:
 resources:
   requests:
     cpu: 250m
-    memory: 6Gi
+    memory: 12Gi
   limits:
-    cpu: 250m
-    memory: 6Gi
+    cpu: 1000m
+    memory: 12Gi
 
 serviceMonitor:
   scrapeTimeout: 50s


### PR DESCRIPTION
Bumping these limits excessively high; they
really ought not to stay here but I want some
data to try and gracefully resolve T354048
particularly given I'm the only engineer here today