### PR TITLE
fix: tf-module-buckets-2 tag was missing from CHANGELOG

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-# tf-module-buckets-2
+# tf-module-buckets-3
 - Add iam members and hmac keys for static assets in module
 
 # tf-module-monitoring-24


### PR DESCRIPTION
In #1372 an incorrect changelog entry was added as an existing tag was missing from the changelog.