### PR TITLE
fix: add iam members and hmac keys for SQL backups in buckets module

### DIFF
--- a/tf/env/production/buckets.tf
+++ b/tf/env/production/buckets.tf
@@ -7,4 +7,3 @@ module "production-buckets" {
   static_bucket_writer_account = google_service_account.api.email
   user_object_admins           = var.terraformers
 }
-

--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-buckets-4
+- Add iam members and hmac keys for SQL backups in buckets module
+
 # tf-module-buckets-3
 - Add iam members and hmac keys for static assets in module
 

--- a/tf/modules/buckets/main.tf
+++ b/tf/modules/buckets/main.tf
@@ -84,6 +84,26 @@ resource "google_storage_bucket_iam_policy" "policy" {
   policy_data = data.google_iam_policy.transfer_job.policy_data
 }
 
+resource "google_storage_hmac_key" "backup-upload-key" {
+  service_account_email = google_service_account.dev-backup-upload.email
+}
+
+resource "google_storage_bucket_iam_member" "backup-upload" {
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.dev-backup-upload.email}"
+  bucket = local.gcs_sql_bucket_backup_name
+}
+
+resource "kubernetes_secret" "gcs-hmac-key" {
+  metadata {
+    name = "gcs-hmac-key"
+  }
+  data = {
+    "access-key" = google_storage_hmac_key.backup-upload-key.access_id
+    "secret-key" = google_storage_hmac_key.backup-upload-key.secret
+  }
+}
+
 ## Backup job T302563
 resource "google_storage_transfer_job" "static-bucket-nightly-backup" {
   description = "Nightly backup of static bucket"


### PR DESCRIPTION
The HMAC keys that are currently in use by the SQL backup suffer from the same problem as #1372 as they grant the keys permissions beyond the bucket in use for backups.

This PR adds a properly scoped key to the `buckets` terraform module. In a second PR we can remove the old keys and start consuming these ones in the respective environments.