### PR TITLE
fix(tf): resource name is used twice in buckets module

### DIFF
--- a/tf/modules/buckets/main.tf
+++ b/tf/modules/buckets/main.tf
@@ -94,7 +94,7 @@ resource "google_storage_bucket_iam_member" "backup-upload" {
   bucket = local.gcs_sql_bucket_backup_name
 }
 
-resource "kubernetes_secret" "gcs-hmac-key" {
+resource "kubernetes_secret" "backup-hmac-key" {
   metadata {
     name = "gcs-hmac-key"
   }

--- a/tf/modules/buckets/main.tf
+++ b/tf/modules/buckets/main.tf
@@ -96,7 +96,7 @@ resource "google_storage_bucket_iam_member" "backup-upload" {
 
 resource "kubernetes_secret" "backup-hmac-key" {
   metadata {
-    name = "gcs-hmac-key"
+    name = "backup-hmac-key"
   }
   data = {
     "access-key" = google_storage_hmac_key.backup-upload-key.access_id


### PR DESCRIPTION
#1377 contained a mistake where the resource name for the HMAC keys would be duplicated.