### PR TITLE
chore(kube-state-metrics): also skip qs-jobs namespace in production

### DIFF
--- a/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/kube-prometheus-stack.values.yaml.gotmpl
@@ -27,6 +27,9 @@ grafana:
       cpu: 100m
       memory: 128Mi
 
+kube-state-metrics:
+  namespacesDenylist: 'qs-jobs'
+
 # turning off most k8s component scraping as we are not
 # interested right now
 kubeScheduler:

--- a/k8s/helmfile/env/staging/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/kube-prometheus-stack.values.yaml.gotmpl
@@ -1,2 +1,1 @@
-kube-state-metrics:
-  namespacesDenylist: 'qs-jobs'
+# staging matches production


### PR DESCRIPTION
So far this seems to work as intended in staging (i.e. no rise in the number of ingested prometheus samples) after deploying #1405 and triggering a rebuild at 12:21 chart time:

![image](https://github.com/wmde/wbaas-deploy/assets/1662740/821ed56b-f1b8-498e-9880-29ae7fb6fcea)
