### PR TITLE
chore(local): set prometheus operator to be more prod-like

### DIFF
--- a/k8s/helmfile/env/local/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/kube-prometheus-stack.values.yaml.gotmpl
@@ -1,12 +1,3 @@
-alertmanager:
-  enabled: false
-
-nodeExporter:
-  enabled: false
-
-kubeStateMetrics:
-  enabled: false
-
 grafana:
   enabled: true
   ingress:


### PR DESCRIPTION
Tweak the local setup to only override the grafana and prometheus config leaving the other services to inherit from prod.

This enables the kubeStateMetrics

Bug: T356049