### PR TITLE
feat(monitoring): add alarm when number of available es shards is low

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,3 +1,6 @@
+# tf-module-monitoring-24
+- Add alarm on low number of available ES shards
+
 # tf-module-buckets-3
 - Add iam members and hmac keys for static assets in module
 

--- a/tf/modules/monitoring/metric-alarms.tf
+++ b/tf/modules/monitoring/metric-alarms.tf
@@ -11,6 +11,19 @@ locals {
       condition_absent        = "300s"
       min_group_by            = "metric.label.es_cluster"
     },
+    "es-cluster-available-shards-${var.environment}" = {
+      display_name            = "Elasticsearch Cluster available shards"
+      filter                  = "metric.type = \"prometheus.googleapis.com/elasticsearch_node_shards_total/gauge\""
+      comparison              = "COMPARISON_GT"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_ACTIVE"
+      trigger_count           = 1
+      # Currently there is a hard limit of 800 shards per node set via REST API.
+      # The alarm is expected to trigger on 90% usage
+      threshold_value  = 720
+      duration         = "60s"
+      condition_absent = "300s"
+      min_group_by     = "metric.label.es_cluster"
+    },
   }
 }
 


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T356254

In staging this created an alarm like this:

![image](https://github.com/wmde/wbaas-deploy/assets/1662740/35909dc8-541b-4d77-9dfc-2de757b99766)
