### PR TITLE
k8s:local upgrade kube-prometheus-stack Chart to 56.6.2

### DIFF
--- a/k8s/helmfile/env/local/kube-prometheus-stack.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/kube-prometheus-stack.values.yaml.gotmpl
@@ -22,7 +22,7 @@ prometheus:
     image:
       registry: quay.io
       repository: prometheus/prometheus
-      tag: v2.42.0
+      tag: v2.49.1
 
   ingress:
     enabled: true

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -209,7 +209,7 @@ releases:
 
   - name: kube-prometheus-stack
     namespace: monitoring
-    version: 45.1.1
+    version: '{{ if eq .Environment.Name "local" }} 56.6.2 {{ else }} 45.1.1 {{ end }}'
     chart: prometheus-community/kube-prometheus-stack
     # https://github.com/roboll/helmfile/issues/1124
     disableValidation: true

--- a/k8s/helmfile/prometheus-operator.yaml
+++ b/k8s/helmfile/prometheus-operator.yaml
@@ -1,5 +1,5 @@
 releases:
   - name: prometheus-operator-crds
     namespace: monitoring
-    version: 2.0.0
+    version: '{{ if eq .Environment.Name "local" }} 9.0.0 {{ else }} 2.0.0 {{ end }}'
     chart: prometheus-community/prometheus-operator-crds


### PR DESCRIPTION
This updates the prometheus stack version through
many major versions.

It also updates the prometheus operator CRDs that
kube-prometheus-stack relies on from 2.0.0 to 9.0.0

While the README[1] lists multiple manual actions required for the kube-prometheus-stack update it appears that the only ones that apply to us are the CRD updates.

I also tested if the CRD updates appear to be backwards compatible and to a very cursory test the older version of kube-prometheus-stack still works and can be fully removed and reapplied to the cluster.

[1] https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack