### PR TITLE
k8s: removed unused old elasticsearch exporter from all environments

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -220,6 +220,7 @@ releases:
     chart: prometheus-community/prometheus-elasticsearch-exporter
     version: 5.2.0
     <<: *default_release
+    installed: false
 
   - name: prometheus-elasticsearch-exporter-1
     namespace: monitoring


### PR DESCRIPTION
This has now been superceded by prometheus-elasticsearch-exporter-1

We must mark as uninstalled before removing the reference to the release in a follow-up commit to actually remove the relevant resources