### PR TITLE
k8s:staging upgrade kube-prometheus-stack Chart to 56.6.2

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -209,7 +209,7 @@ releases:
 
   - name: kube-prometheus-stack
     namespace: monitoring
-    version: '{{ if eq .Environment.Name "local" }} 56.6.2 {{ else }} 45.1.1 {{ end }}'
+    version: '{{ if eq .Environment.Name "production" }} 45.1.1 {{ else }} 56.6.2 {{ end }}'
     chart: prometheus-community/kube-prometheus-stack
     # https://github.com/roboll/helmfile/issues/1124
     disableValidation: true

--- a/k8s/helmfile/prometheus-operator.yaml
+++ b/k8s/helmfile/prometheus-operator.yaml
@@ -1,5 +1,5 @@
 releases:
   - name: prometheus-operator-crds
     namespace: monitoring
-    version: '{{ if eq .Environment.Name "local" }} 9.0.0 {{ else }} 2.0.0 {{ end }}'
+    version: '{{ if eq .Environment.Name "production" }} 2.0.0 {{ else }} 9.0.0 {{ end }}'
     chart: prometheus-community/prometheus-operator-crds


### PR DESCRIPTION
This does not update the GKE prometheus-engine/prometheus image. I propose doing this as a separate second step after the rest of the stack is present in both staging and production

Bug: T356049