### PR TITLE
fix: tf-module-monitoring-24 in changelog already exists

### DIFF
--- a/tf/modules/CHANGELOG.md
+++ b/tf/modules/CHANGELOG.md
@@ -1,4 +1,4 @@
-# tf-module-monitoring-24
+# tf-module-monitoring-25
 - Add alarm on low number of available ES shards
 
 # tf-module-buckets-3


### PR DESCRIPTION
I got the next tag for the module wrong in #1414 