### PR TITLE
fix(k8s): add environment definitions to subhelmfiles

### DIFF
--- a/k8s/helmfile/istio-control-plane.yaml
+++ b/k8s/helmfile/istio-control-plane.yaml
@@ -1,3 +1,24 @@
+environments:
+  default:
+    kubeContext: INVALID-ENVIRONMENT
+  production:
+    kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-3
+    values:
+      - ./env/production/base.yaml
+      - ./env/production/private.yaml
+  staging:
+    kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-2
+    values:
+      - ./env/staging/base.yaml
+      - ./env/staging/private.yaml
+  local:
+    kubeContext: minikube-wbaas
+    values:
+      - ./env/local/base.yaml
+      - ./env/local/private.yaml
+
+---
+
 releases:
   - name: istio-base
     namespace: istio-system

--- a/k8s/helmfile/prometheus-operator.yaml
+++ b/k8s/helmfile/prometheus-operator.yaml
@@ -1,3 +1,24 @@
+environments:
+  default:
+    kubeContext: INVALID-ENVIRONMENT
+  production:
+    kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-3
+    values:
+      - ./env/production/base.yaml
+      - ./env/production/private.yaml
+  staging:
+    kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-2
+    values:
+      - ./env/staging/base.yaml
+      - ./env/staging/private.yaml
+  local:
+    kubeContext: minikube-wbaas
+    values:
+      - ./env/local/base.yaml
+      - ./env/local/private.yaml
+
+---
+
 releases:
   - name: prometheus-operator-crds
     namespace: monitoring


### PR DESCRIPTION
It appears that without these present helmfile uses the default environment (and thus kubecontext) for applying changes due to these subhelm files.

This is a big issue; it means that you may accidentally apply to the wrong environment and there will be no hint