### PR TITLE
fix(k8s): helm diff in kube-prometheus-stack-operator ClusterRole

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -41,6 +41,8 @@ environments:
 # TODO: does this need increasing?
 helmDefaults:
   timeout: 1200
+  diffArgs:
+    - "--api-versions=discovery.k8s.io/v1/EndpointSlice" # See T358468
 
 # Path to helmfiles to process BEFORE releases
 # All the nested state files under `helmfiles:` is processed in the order of definition.


### PR DESCRIPTION
This patch hints to helm the capabilities to make the templating behave properly[1] when using .Capabilities.APIVersions.Has in charts.

[1] - https://github.com/helm/helm/issues/10760

Bug: T358468