### PR TITLE
add `.tool-versions`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,11 @@
+kubectl 1.27.4 
+minikube 1.31.1
+terraform 1.5.4
+helm 3.12.2 
+helmfile 0.162.0
+skaffold 2.6.2 
+yq 4.34.2
+minio 2023-08-09T23-30-22Z
+mc 2023-08-08T17-23-59Z
+istioctl 1.19.3
+

--- a/.tool-versions
+++ b/.tool-versions
@@ -3,7 +3,7 @@ minikube 1.31.1
 terraform 1.5.4
 helm 3.12.2 
 helmfile 0.162.0
-skaffold 2.6.2 
+skaffold 2.9.0 
 yq 4.34.2
 minio 2023-08-09T23-30-22Z
 mc 2023-08-08T17-23-59Z


### PR DESCRIPTION
This adds a `.tool-versions` file.

The concept of this file stems from the tool `asdf`: https://github.com/asdf-vm/asdf
https://asdf-vm.com/manage/configuration.html

The idea is that even if you don't use this tool, we can use this file as a reference of the recommended versions of the cli tools we are using.

For this PR, please check the versions of the tools you currently use and suggest newer versions if present on your system.

