### PR TITLE
chore(api): disable horizon in staging

### DIFF
--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -58,9 +58,9 @@ storage:
   secretKeySecretName: public-assets-hmac-key
 
 queue:
-  queueNames: ['default']
+  queueNames: ['default', 'manual-intervention']
   horizon:
-    enabled: true
+    enabled: false
     queueNames: ['default', 'manual-intervention']
 
 replicaCount:


### PR DESCRIPTION
Jobs stopped running in staging after deploying #1481 so I disable Hoizon until I figured out why.