### PR TITLE
production: reduce queryservice-updater replica 0

### DIFF
--- a/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
@@ -1,4 +1,4 @@
-replicaCount: 3
+replicaCount: 0
 
 image:
   repository: ghcr.io/wbstack/queryservice-updater


### PR DESCRIPTION
We want to confirm if the CPU exhaustion on the queryservice is due to the updater or due to other traffic.

Bug: T361551