### PR TITLE
chore(qs-gateway): update image to 2.3 and update chart

### DIFF
--- a/k8s/helmfile/env/local/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice-gateway.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "2.2"
+  tag: "2.3"
 
 resources:
   requests:

--- a/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "2.2"
+  tag: "2.3"
 
 resources:
   requests:

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -183,7 +183,7 @@ releases:
   - name: queryservice-gateway
     namespace: default
     chart: wbstack/queryservice-gateway
-    version: 0.1.3
+    version: 0.2.0
     <<: *default_release
 
   - name: queryservice-updater


### PR DESCRIPTION
Ships https://github.com/wbstack/queryservice-gateway/pull/164 and https://github.com/wbstack/charts/pull/142