### PR TITLE
Revert "chore(wdqs): use 0.3.137-wbstack.1 in staging and local"

### DIFF
--- a/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "0.3.137-wbstack.1"
+  tag: "0.3.135-wbstack.1"
 
 useProbes: false
 

--- a/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "0.3.137-wbstack.1"
+  tag: "0.3.135-wbstack.1"
 
 app:
   heapSize: 1g


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1536

It seems this introduces a lag in the updater for reasons I don't understand yet.