### PR TITLE
argo: yaml hotfix

### DIFF
--- a/k8s/helmfile/argo-cd.yaml
+++ b/k8s/helmfile/argo-cd.yaml
@@ -8,6 +8,8 @@ environments:
   local:
     kubeContext: minikube-wbaas
 
+---
+
 repositories:
   - name: argo-cd
     url: https://argoproj.github.io/argo-helm


### PR DESCRIPTION
When deploying #1545 I encountered this warning:

```
WARNING: environments and releases cannot be defined within the same YAML part. Use --- to extract the environments into a dedicated part
```

