### PR TITLE
argo: add local ingress conf

### DIFF
--- a/doc/deployments/argocd.md
+++ b/doc/deployments/argocd.md
@@ -6,7 +6,11 @@
 1. Reset the admin password by running `./bin/get-argocd-password`
 1. Enable admin access by flipping `admin.enabled` to `true` in our values file (or manually in the ConfigMap `argocd-cm`)
     - this is enabled for local clusters by default
-2. Forward port `8080` of the deployment `argo-cd-base-argocd-server`
-    - `kubectl -n argocd port-forward deployments/argo-cd-base-argocd-server 8080`
-3. Visit https://localhost:8080/ and log in (username `admin`).
-    - for local clusters TLS is disabled: http://localhost:8080/
+2. Access the web interface and log in (username `admin`)
+    - a) local - http://argo.wbaas.localhost/
+    - b) staging/production - https://localhost:8080/
+      - Forward port `8080` of the deployment `argo-cd-base-argocd-server`
+
+        ```
+        kubectl -n argocd port-forward deployments/argo-cd-base-argocd-server 8080`
+        ```

--- a/k8s/helmfile/env/local/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/argo-cd-base.values.yaml.gotmpl
@@ -16,3 +16,18 @@ configs:
           color:white;
         }
     }
+
+global:
+  domain: argo.wbaas.localhost
+
+certificate:
+  enabled: true
+
+server:
+  ingress:
+    enabled: true
+    ingressClassName: nginx
+    annotations:
+      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
+    tls: false


### PR DESCRIPTION
This PR adds http ingress configuration for the local minikube deployment of argocd: http://argo.wbaas.localhost/
