### PR TITLE
feature(staging): add additional platform summary metrics

### DIFF
--- a/tf/env/staging/monitoring.tf
+++ b/tf/env/staging/monitoring.tf
@@ -1,24 +1,9 @@
 module "staging-monitoring" {
-  source = "git::ssh://git@github.com/wmde/wbaas-deploy//tf//modules/monitoring?ref=tf-module-monitoring-26"
+  source = "../../modules-next/monitoring"
   providers = {
     kubernetes = kubernetes.wbaas-2
   }
   cluster_name                = local.staging_cluster_name
   environment                 = "staging"
   monitoring_email_group_name = google_monitoring_notification_channel.monitoring_email_group.name
-  platform_summary_metrics = toset([
-    "active",
-    "total",
-    "deleted",
-    "inactive",
-    "empty",
-    "total_non_deleted_users",
-    "total_non_deleted_active_users",
-    "total_non_deleted_pages",
-    "total_non_deleted_edits",
-    "wikis_created_PT24H",
-    "wikis_created_P30D",
-    "users_created_PT24H",
-    "users_created_P30D",
-  ])
 }

--- a/tf/modules-next/monitoring/elasticsearch-pv.tf
+++ b/tf/modules-next/monitoring/elasticsearch-pv.tf
@@ -1,0 +1,42 @@
+locals {
+  elasticsearch_pv_critical_utilization_threshold = 0.85 # 85%, alert triggers if metric is above this value
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_elasticsearch_pv_critical_utilization" {
+  display_name = "(${var.cluster_name}): critical Elastic Search PV utilization"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+
+  documentation {
+    content = "Alert triggers when the disk space utilization of the Elastic Search data PV is reaching a critical level (over ${local.elasticsearch_pv_critical_utilization_threshold * 100}%)"
+  }
+
+  conditions {
+    display_name = "(${var.cluster_name}): critical Elastic Search PV utilization"
+    condition_threshold {
+      filter = <<-EOT
+                metric.type="kubernetes.io/pod/volume/utilization"
+                resource.label."cluster_name"=${var.cluster_name}
+                resource.label."pod_name"=starts_with("elasticsearch-")
+                resource.type="k8s_pod"
+                metric.label."volume_name"="elasticsearch-master"
+            EOT
+
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.elasticsearch_pv_critical_utilization_threshold
+
+      aggregations {
+        alignment_period     = "120s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/tf/modules-next/monitoring/elasticsearch.tf
+++ b/tf/modules-next/monitoring/elasticsearch.tf
@@ -1,0 +1,38 @@
+
+resource "google_logging_metric" "elasticsearch-metrics" {
+  for_each = var.elasticsearch_metrics
+
+  filter = <<-EOT
+        resource.type="k8s_container"
+        resource.labels.cluster_name="${var.cluster_name}"
+        resource.labels.namespace_name="default"
+        labels.k8s-pod/job-name:"stats-cron-" severity>=DEFAULT
+    EOT
+  label_extractors = {
+    "Node" = "EXTRACT(jsonPayload.name)"
+  }
+  name            = "${var.cluster_name}-elasticsearch-metrics-${each.value}"
+  value_extractor = "REGEXP_EXTRACT(jsonPayload.\"${each.value}\", \"(\\\\d+)\")"
+
+  bucket_options {
+
+    exponential_buckets {
+      growth_factor      = 2
+      num_finite_buckets = 64
+      scale              = 0.01
+    }
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    unit        = "1"
+    value_type  = "DISTRIBUTION"
+
+    labels {
+      key        = "Node"
+      value_type = "STRING"
+    }
+  }
+
+  timeouts {}
+}

--- a/tf/modules-next/monitoring/main.tf
+++ b/tf/modules-next/monitoring/main.tf
@@ -1,0 +1,37 @@
+#https://www.percona.com/blog/2014/10/08/mysql-replication-got-fatal-error-1236-causes-and-cures/
+resource "google_logging_metric" "mariadb-server_errno-1236" {
+  name   = "${var.cluster_name}-mariadb-sql-errno-1236-error-count"
+  filter = "resource.labels.cluster_name=\"${var.cluster_name}\" AND resource.labels.container_name=\"mariadb\" AND textPayload:\"server_errno=1236\""
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_replica_failure" {
+  display_name = "(${var.cluster_name}): SQL replica error 1236 alert policy"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+  documentation {
+    content = "**Alert trigger when SQL replication fails on the MariaDB replica database with error code 1236.**\nThis error occurs when the slave server required binary log for replication no longer exists on the master database server. In one of the scenarios for this, the slave server is stopped for some reason for a few hours/days and when you resume replication on the slave it fails with the above error. see [here](https://www.percona.com/blog/2014/10/08/mysql-replication-got-fatal-error-1236-causes-and-cures/)"
+  }
+  conditions {
+    display_name = "(${var.cluster_name}): SQL replica errorno 1236"
+    condition_threshold {
+      # resource.type needed because of https://github.com/hashicorp/terraform-provider-google/issues/4165
+      filter     = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.mariadb-server_errno-1236.name}\" AND resource.type=\"k8s_container\""
+      duration   = "60s"
+      comparison = "COMPARISON_GT"
+      aggregations {
+        alignment_period     = "1200s"
+        per_series_aligner   = "ALIGN_RATE"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/tf/modules-next/monitoring/metric-alarms.tf
+++ b/tf/modules-next/monitoring/metric-alarms.tf
@@ -1,0 +1,90 @@
+locals {
+  alarms = {
+    "es-cluster-health-${var.environment}" = {
+      display_name            = "Elasticsearch Cluster Health Status"
+      filter                  = "metric.type = \"prometheus.googleapis.com/elasticsearch_cluster_health_status/gauge\" AND metric.labels.color = \"green\""
+      comparison              = "COMPARISON_LT"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_ACTIVE"
+      trigger_count           = 1
+      threshold_value         = 1
+      duration                = "60s"
+      condition_absent        = "300s"
+      min_group_by            = "metric.label.es_cluster"
+    },
+    "es-cluster-available-shards-${var.environment}" = {
+      display_name            = "Elasticsearch Cluster available shards"
+      filter                  = "metric.type = \"prometheus.googleapis.com/elasticsearch_node_shards_total/gauge\""
+      comparison              = "COMPARISON_GT"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_ACTIVE"
+      trigger_count           = 1
+      # Currently there is a hard limit of 800 shards per node set via REST API.
+      # The alarm is expected to trigger on 90% usage
+      threshold_value  = 720
+      duration         = "60s"
+      condition_absent = "300s"
+      min_group_by     = "metric.label.es_cluster"
+    },
+    "api-qs-batches-backpressure-${var.environment}" = {
+      display_name            = "Platform API Queryservice Batches Backpressure"
+      filter                  = "metric.type = \"prometheus.googleapis.com/platform_api_qs_batches_pending_batches/gauge\""
+      comparison              = "COMPARISON_GT"
+      evaluation_missing_data = "EVALUATION_MISSING_DATA_ACTIVE"
+      trigger_count           = 1
+      threshold_value         = 100
+      duration                = "60s"
+      condition_absent        = "300s"
+      min_group_by            = "metric.label.cluster"
+    },
+  }
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_prometheus_metric" {
+  for_each = local.alarms
+
+  display_name = "Metric check failed (${var.environment}): ${each.value.display_name}"
+
+  documentation {
+    content = "This alert fires if the metric ${each.value.display_name} does not meet its expected status."
+  }
+
+  conditions {
+    display_name = each.value.display_name
+    condition_threshold {
+      filter                  = "resource.type = \"prometheus_target\" AND resource.labels.cluster = \"${var.cluster_name}\" AND ${each.value.filter}"
+      evaluation_missing_data = each.value.evaluation_missing_data
+      comparison              = each.value.comparison
+      duration                = each.value.duration
+      trigger {
+        count = each.value.trigger_count
+      }
+      threshold_value = each.value.threshold_value
+      aggregations {
+        alignment_period     = "300s"
+        cross_series_reducer = "REDUCE_MIN"
+        group_by_fields = [
+          each.value.min_group_by,
+        ]
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+  conditions {
+    display_name = "${each.value.display_name} absent"
+    condition_absent {
+      duration = each.value.condition_absent
+      filter   = "resource.type = \"prometheus_target\" AND resource.labels.cluster = \"${var.cluster_name}\" AND ${each.value.filter}"
+      aggregations {
+        alignment_period     = "300s"
+        cross_series_reducer = "REDUCE_MIN"
+        group_by_fields = [
+          each.value.min_group_by,
+        ]
+        per_series_aligner = "ALIGN_MEAN"
+      }
+    }
+  }
+  combiner = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+}

--- a/tf/modules-next/monitoring/platform-summary.tf
+++ b/tf/modules-next/monitoring/platform-summary.tf
@@ -1,0 +1,33 @@
+resource "google_logging_metric" "platform-summary-metrics" {
+  for_each = var.platform_summary_metrics
+
+  filter          = <<-EOT
+        resource.type="k8s_container"
+        resource.labels.cluster_name="${var.cluster_name}"
+        resource.labels.namespace_name="default"
+        labels.k8s-pod/app_kubernetes_io/component="queue-default"
+        labels.k8s-pod/app_kubernetes_io/instance="api"
+        labels.k8s-pod/app_kubernetes_io/name="api" severity>=DEFAULT
+        jsonPayload.platform_summary_version="v1"
+    EOT
+  name            = "${var.cluster_name}-platform-summary-${each.value}"
+  value_extractor = "REGEXP_EXTRACT(jsonPayload.\"${each.value}\", \"(\\\\d+)\")"
+
+  bucket_options {
+
+    exponential_buckets {
+      growth_factor      = 2
+      num_finite_buckets = 64
+      scale              = 0.01
+    }
+  }
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    unit        = "1"
+    value_type  = "DISTRIBUTION"
+
+  }
+
+  timeouts {}
+}

--- a/tf/modules-next/monitoring/providers.tf
+++ b/tf/modules-next/monitoring/providers.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    google = {
+
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.5.0"
+    }
+  }
+}

--- a/tf/modules-next/monitoring/queryservice-pv.tf
+++ b/tf/modules-next/monitoring/queryservice-pv.tf
@@ -1,0 +1,42 @@
+locals {
+  queryservice_pv_critical_utilization_threshold = 0.85 # 85%, alert triggers if metric is above this value
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_queryservice_pv_critical_utilization" {
+  display_name = "(${var.cluster_name}): critical Query Service PV utilization"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+
+  documentation {
+    content = "Alert triggers when the disk space utilization of the Query Service data PV is reaching a critical level (over ${local.queryservice_pv_critical_utilization_threshold * 100}%)"
+  }
+
+  conditions {
+    display_name = "(${var.cluster_name}): critical Query Service PV utilization"
+    condition_threshold {
+      filter = <<-EOT
+                metric.type="kubernetes.io/pod/volume/utilization"
+                resource.label."cluster_name"=${var.cluster_name}
+                resource.label."pod_name"=starts_with("queryservice-")
+                resource.type="k8s_pod"
+                metric.label."volume_name"="data"
+            EOT
+
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.queryservice_pv_critical_utilization_threshold
+
+      aggregations {
+        alignment_period     = "120s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_NONE"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/tf/modules-next/monitoring/replication-lag-alert.tf
+++ b/tf/modules-next/monitoring/replication-lag-alert.tf
@@ -1,0 +1,40 @@
+# see customReadinessProbe on the sql values.yaml
+resource "google_logging_metric" "mariadb-replica-readiness-probe-failure" {
+  name        = "${var.cluster_name}-mariadb-replica-readiness-probe-failure"
+  description = "A log based metric for failures of the replica readiness probe lagging behind the primary"
+
+  # Filter for the secondary pod and look for readiness probe failures
+  filter = "resource.labels.cluster_name=\"${var.cluster_name}\" AND resource.labels.pod_name:\"sql-mariadb-secondary-\" AND resource.type=\"k8s_pod\" AND severity=WARNING AND jsonPayload.message:\"Readiness probe failed:\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_replica_readiniess_failure" {
+  display_name = "(${var.cluster_name}): SQL replica readiness probe failure"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+  documentation {
+    content = "Alert triggers when the replica state is lagging behind the master state by more than 60 seconds.\n For what are possible causes of a replication lag see [here](https://blogs.oracle.com/mysql/post/what-causes-replication-lag) "
+  }
+  conditions {
+    display_name = "(${var.cluster_name}): SQL replica readiness probe failure"
+    condition_threshold {
+      filter     = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.mariadb-replica-readiness-probe-failure.name}\" AND resource.type=\"k8s_pod\""
+      duration   = "0s"
+      comparison = "COMPARISON_GT"
+      aggregations {
+        alignment_period     = "300s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/tf/modules-next/monitoring/sql-backup-failure-alert.tf
+++ b/tf/modules-next/monitoring/sql-backup-failure-alert.tf
@@ -1,0 +1,83 @@
+resource "google_logging_metric" "sql_logical_backup_success" {
+  name        = "${var.cluster_name}-sql-logic-backup"
+  description = "A log based metric for monitoring sql logical backups."
+  filter      = "resource.labels.cluster_name=\"${var.cluster_name}\" AND resource.labels.pod_name:\"sql-logic-backup\" AND resource.type=\"k8s_container\" AND severity=INFO AND textPayload:\"Finished dump at:\""
+
+  metric_descriptor {
+    metric_kind = "DELTA"
+    value_type  = "INT64"
+  }
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_sql_logical_backup_failure" {
+  display_name = "(${var.cluster_name}): SQL logical backup failure"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+  documentation {
+    content = "Alert fires when no SQL logical backup was created in the last 24.5 hours see [here](https://github.com/wmde/wbaas-deploy/blob/main/doc/backups/SQL/logical-sql-manually-taking-a-backup.md) for how to run backups manually."
+  }
+
+  conditions {
+    display_name = "(${var.cluster_name}): SQL logical backup failure"
+    condition_absent {
+      filter   = "metric.type=\"logging.googleapis.com/user/${google_logging_metric.sql_logical_backup_success.name}\" AND resource.type=\"k8s_container\""
+      duration = "86400s"
+
+      aggregations {
+        cross_series_reducer = "REDUCE_COUNT"
+        per_series_aligner   = "ALIGN_COUNT"
+        alignment_period     = "900s"
+        group_by_fields = [
+          "resource.labels.container_name",
+        ]
+      }
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+locals {
+  sql_backup_disk_critical_usage_threshold = 0.8 # 80%, alert triggers if metric is above this value
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_sql_logical_backup_pv_critical_utilization" {
+  display_name = "(${var.cluster_name}): critical SQL logical backup PV utilization"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+
+  documentation {
+    content = "Alert fires when the PV used for the SQL backups is reaching a critical level (above ${local.sql_backup_disk_critical_usage_threshold * 100}%)."
+  }
+
+  conditions {
+    display_name = "(${var.cluster_name}): critical SQL logical backup PV utilization"
+    condition_threshold {
+      filter = <<-EOT
+                metric.type="kubernetes.io/pod/volume/utilization"
+                resource.type="k8s_pod"
+                resource.label.cluster_name="${var.cluster_name}"
+                resource.label.pod_name=starts_with("sql-logic-backup-")
+            EOT
+
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.sql_backup_disk_critical_usage_threshold
+
+      aggregations {
+        alignment_period     = "120s"
+        per_series_aligner   = "ALIGN_MAX"
+        cross_series_reducer = "REDUCE_MAX"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/tf/modules-next/monitoring/sql-pv.tf
+++ b/tf/modules-next/monitoring/sql-pv.tf
@@ -1,0 +1,81 @@
+locals {
+  sql_pv_critical_utilization_threshold = 0.85 # 85%, alert triggers if metric is above this value
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_sql_primary_pv_critical_utilization" {
+  display_name = "(${var.cluster_name}): critical SQL primary PV utilization"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+
+  documentation {
+    content = "Alert triggers when the disk space utilization of the SQL primary data PV is reaching a critical level (over ${local.sql_pv_critical_utilization_threshold * 100}%)"
+  }
+
+  conditions {
+    display_name = "(${var.cluster_name}): critical SQL primary PV utilization"
+    condition_threshold {
+      filter = <<-EOT
+                metric.type="kubernetes.io/pod/volume/utilization"
+                resource.label."cluster_name"=${var.cluster_name}
+                resource.label."pod_name"="sql-mariadb-primary-0"
+                resource.type="k8s_pod"
+                metric.label."volume_name"="data"
+            EOT
+
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.sql_pv_critical_utilization_threshold
+
+      aggregations {
+        alignment_period     = "120s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "alert_policy_sql_secondary_pv_critical_utilization" {
+  display_name = "(${var.cluster_name}): critical SQL secondary PV utilization"
+  combiner     = "OR"
+  notification_channels = [
+    "${var.monitoring_email_group_name}"
+  ]
+
+  documentation {
+    content = "Alert triggers when the disk space utilization of the SQL secondary data PV is reaching a critical level (over ${local.sql_pv_critical_utilization_threshold * 100}%)"
+  }
+
+  conditions {
+    display_name = "(${var.cluster_name}): critical SQL secondary PV utilization"
+    condition_threshold {
+      filter = <<-EOT
+                metric.type="kubernetes.io/pod/volume/utilization"
+                resource.label."cluster_name"=${var.cluster_name}
+                resource.label."pod_name"="sql-mariadb-secondary-0"
+                resource.type="k8s_pod"
+                metric.label."volume_name"="data"
+            EOT
+
+      duration        = "60s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = local.sql_pv_critical_utilization_threshold
+
+      aggregations {
+        alignment_period     = "120s"
+        per_series_aligner   = "ALIGN_MEAN"
+        cross_series_reducer = "REDUCE_SUM"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+}

--- a/tf/modules-next/monitoring/variables.tf
+++ b/tf/modules-next/monitoring/variables.tf
@@ -1,0 +1,47 @@
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster"
+}
+
+variable "monitoring_email_group_name" {
+  type        = string
+  description = "Name of the monitoring resource that will receive alerts"
+}
+
+variable "elasticsearch_metrics" {
+  type        = set(string)
+  description = "Metrics to look for in the json payload"
+  default = [
+    "heap.percent",
+    "ram.percent",
+    "disk.used_percent",
+    "load_1m"
+  ]
+}
+
+variable "platform_summary_metrics" {
+  type        = set(string)
+  description = "Metrics to look for in the json payload"
+  default = [
+    "total",
+    "deleted",
+    "empty",
+    "total_non_deleted_users",
+    "total_non_deleted_active_users",
+    "total_non_deleted_pages",
+    "total_non_deleted_edits",
+    "total_items_count",
+    "total_properties_count",
+    "edited_last_90_days",
+    "not_edited_last_90_days",
+    "wikis_created_PT24H",
+    "wikis_created_P30D",
+    "users_created_PT24H",
+    "users_created_P30D",
+  ]
+}
+
+variable "environment" {
+  type        = string
+  description = "Human friendly name of the target environment. Example: production"
+}


### PR DESCRIPTION
This follows the pattern of ADR 12 and introduces a "next" version of the monitoring module.

This next version of the monitoring module contains the mostly renamed not_edited_last_90_days and edited_last_90_days as well as the new total_properties_count and total_items_count as default log based metrics to be created.

This new module is sourced and the overriding of
platform_summary_metrics variable is removed since it is no longer necessary

Bug: T364452
Bug: T314481