### PR TITLE
fix: production TF remove monitoring param override

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -6,21 +6,6 @@ module "production-monitoring" {
   environment                 = "production"
   cluster_name                = local.production_cluster_name
   monitoring_email_group_name = google_monitoring_notification_channel.monitoring_email_group.name
-  platform_summary_metrics = toset([
-    "active",
-    "total",
-    "deleted",
-    "inactive",
-    "empty",
-    "total_non_deleted_users",
-    "total_non_deleted_active_users",
-    "total_non_deleted_pages",
-    "total_non_deleted_edits",
-    "wikis_created_PT24H",
-    "wikis_created_P30D",
-    "users_created_PT24H",
-    "users_created_P30D",
-  ])
 }
 
 resource "google_logging_metric" "production-site-request-count" {


### PR DESCRIPTION
This patch removes an override that prevents the default platform summary metrics from being using in the module