### PR TITLE
Revert "Production: Deploy new Platform API image 10x.8.4"

### DIFF
--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 10x.8.4
+  tag: 10x.8.3
 
 replicaCount:
   web: 1


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1647

Applying the migration failed

```
In Connection.php line 824:
                                                                                                                                                                                                           
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '647' for key 'wiki_lifecycle_events_wiki_id_unique' (Connection: mysql, SQL: alter table `wiki_lifecycle_events` add unique `wik  
  i_lifecycle_events_wiki_id_unique`(`wiki_id`))                                                                                                                                                           
                                                                                                                                                                                                           

In Connection.php line 587:
                                                                                                                              
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '647' for key 'wiki_lifecycle_events_wiki_id_unique'  
```

which means the cleanup logic must somehow leave multiple items for certain wikis.