### PR TITLE
fix(redirects): later chart versions disable server snippets by default

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -1,4 +1,5 @@
 controller:
+  allowSnippetAnnotations: true
   service:
     loadBalancerIP: {{ .Values.ip }}
     externalTrafficPolicy: Local


### PR DESCRIPTION
The `status.wikibase.cloud` redirect was broken since merging #1638. It seems this was caused by including https://github.com/kubernetes/ingress-nginx/pull/10393, silently removing the required annotation from the ingress.

This PR enables the setting again, restoring behavior as of #1632  