### PR TITLE
production(mediwiki): increase web replica count

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -3,7 +3,7 @@ image:
 
 replicaCount:
   backend: 2
-  web: 2
+  web: 3
   webapi: 2
   alpha: 1
 


### PR DESCRIPTION
This patch attempts to increase the number of replicas of mediawiki web to see if spreading the load more thinly results in less restarts of these web pods

Bug: T368360