### PR TITLE
chore(minikube): increase k8s version to 1.28.9

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ help:
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube
 minikube-start:
-	minikube --profile minikube-wbaas start --kubernetes-version=1.26.5
+	minikube --profile minikube-wbaas start --kubernetes-version=1.28.9
 
 .PHONY: minikube-stop
 minikube-stop: # @HELP Stop the local minikube cluster


### PR DESCRIPTION
## Describe the changes
This increases the k8s version to match the GKE one in production.

## This is what I need help with
Shouldn't need any more precise review (obviously this won't start a new cluster until make `minikube-start` is called on each engineer's machine.

### Prior discussion
As discussed in the daily this means it's probably also a good point for engineers to remember to update their `kubectl` client

Bug: T369255