### PR TITLE
chore(k8s): bump kubectl version in tool-versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
-kubectl 1.27.4 
+kubectl 1.28.9
 minikube 1.31.1
 opentofu 1.6.2
 helm 3.12.2 


### PR DESCRIPTION
## Describe the changes
After the increase in kubernetes version both automatically on
GKE but also locally in #1664 it would be nice to update this version
we should keep it close to production versions and always within one
minor version.

## This is what I need help with
Nothing

## Link to Phabricator
None

### Prior discussion
See: https://github.com/wmde/wbaas-deploy/pull/1664#pullrequestreview-2158383591
