### PR TITLE
(argo) add makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,6 +131,12 @@ argo-sync: # @HELP Sync app-of-apps in ArgoCD (which contains all other Applicat
 argo-sync: argo-sync-app-of-apps
 
 .PHONY: argo-list
+argo-list: # @HELP List current applications and their state in ArgoCD
 argo-list:
 	./bin/argocli app list
+
+.PHONY: argo-port-forward
+argo-port-forward: # @HELP Port forwards the ArgoCD UI to localhost:8080
+argo-port-forward:
+	kubectl -n argocd port-forward deployments/argo-cd-base-argocd-server 8080
 

--- a/Makefile
+++ b/Makefile
@@ -129,3 +129,8 @@ argo-sync-%:
 .PHONY: argo-sync
 argo-sync: # @HELP Sync app-of-apps in ArgoCD (which contains all other Applications)
 argo-sync: argo-sync-app-of-apps
+
+.PHONY: argo-list
+argo-list:
+	kubectl -n argocd exec statefulsets/argo-cd-base-argocd-application-controller -- argocd --core app list
+

--- a/Makefile
+++ b/Makefile
@@ -112,3 +112,20 @@ skaffold-%:
 skaffold-run: # @HELP Run all local modules using skaffold
 skaffold-run:
 	cd ./skaffold && skaffold run --kube-context minikube-wbaas
+
+.PHONY: argo-reset-password
+argo-reset-password: # @HELP Reset the admin password for the ArgoCD of the current context
+argo-reset-password:
+	./bin/reset-argocd-password
+
+argo-sync-app-of-apps:
+argo-sync-ui: # @HELP Sync ui in ArgoCD
+.PHONY: argo-sync-%
+argo-sync-%: # @HELP Sync any Application defined in ArgoCD
+argo-sync-%: APP=$*
+argo-sync-%:
+	kubectl -n argocd exec statefulsets/argo-cd-base-argocd-application-controller -- argocd --core app sync $(APP)
+
+.PHONY: argo-sync
+argo-sync: # @HELP Sync app-of-apps in ArgoCD (which contains all other Applications)
+argo-sync: argo-sync-app-of-apps

--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ argo-sync-ui: # @HELP Sync ui in ArgoCD
 argo-sync-%: # @HELP Sync any Application defined in ArgoCD
 argo-sync-%: APP=$*
 argo-sync-%:
-	kubectl -n argocd exec statefulsets/argo-cd-base-argocd-application-controller -- argocd --core app sync $(APP)
+	./bin/argocli app sync $(APP)
 
 .PHONY: argo-sync
 argo-sync: # @HELP Sync app-of-apps in ArgoCD (which contains all other Applications)
@@ -132,5 +132,5 @@ argo-sync: argo-sync-app-of-apps
 
 .PHONY: argo-list
 argo-list:
-	kubectl -n argocd exec statefulsets/argo-cd-base-argocd-application-controller -- argocd --core app list
+	./bin/argocli app list
 

--- a/bin/argocli
+++ b/bin/argocli
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n argocd exec statefulsets/argo-cd-base-argocd-application-controller -- argocd --core $*
+

--- a/doc/deployments/argocd.md
+++ b/doc/deployments/argocd.md
@@ -57,5 +57,5 @@ This GitHub workflow runs the script to check if the checked-in values files are
       - Forward port `8080` of the deployment `argo-cd-base-argocd-server`
 
         ```
-        kubectl -n argocd port-forward deployments/argo-cd-base-argocd-server 8080`
+        make argo-port-forward
         ```


### PR DESCRIPTION
<!--
	Please populate this Pull Request template for **every** pull request
	unless there is a really good reason against it. Your reviewer as well
	as your future self will be thankful for the context given.

	If you have specific code level changes to discuss, it's also helpful to
	leave comments about your concerns at line level before requesting review.
-->

## Describe the changes
Adds some makefile targets to sync argo applications (ui and all, via app-of-apps)
and to list available argo applications

This uses a simple bash script `./bin/argocli` that executes the argocd cli client in the application controller pod. This can also be used on its own to use the cli tool in a generic way.

<!--
	To help reviewers with understanding the changes at hand, provide a
	short summary of:
		1. why is this change needed?
		2. what led to choosing the current implementation?
		3. are there any alternative solutions you considered, but did not
           pursue further?
-->


## Link to Phabricator
https://phabricator.wikimedia.org/T360876
<!--
	Provide a link to the relevant Phabricator ticket for this Pull Request.
	If there is none, try to explain what prompted opening this PR (e.g. adhoc
	resolution of an incident, typo fix or similar).
-->

### Prior discussion
https://phabricator.wikimedia.org/T360876#10001045
<!--
	Has there been any in person discussion about this PR that led to the
	current implementation, and which is not documented in the Phabricator
	ticket? In case yes, please provide context about this for the reviewer.
	Feel free to @mention the people involved in the discussion.
-->
