### PR TITLE
chore(mediawiki): enable HPA for MW in local and staging

### DIFF
--- a/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
@@ -1,6 +1,10 @@
 image:
   tag: 1.39-7.4-20240722-0
 
+web:
+  autoscaling:
+    maxReplicas: 2
+
 mw:
   settings:
     # Enable this to increase verbosity of logging in mw pods

--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -7,6 +7,12 @@ replicaCount:
   webapi: 2
   alpha: 1
 
+web:
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+
 mw:
   redis:
     # TODO fixme, no port injected into deployment...

--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -1,6 +1,10 @@
 image:
   tag: 1.39-7.4-20240722-0
 
+web:
+  autoscaling:
+    maxReplicas: 2
+
 mw:
   settings:
     allowedProxyCidr: "10.112.0.0/14"

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -167,7 +167,7 @@ releases:
   - name: mediawiki-139
     namespace: default
     chart: wbstack/mediawiki
-    version: 0.11.2
+    version: '{{ if eq .Environment.Name "production" }}0.11.2{{ else }}0.12.0{{ end }}'
     <<: *default_release
 
   - name: queryservice-ui


### PR DESCRIPTION
## Describe the changes
Uses the chart introduced in wbstack/charts#145

This commit also adds a value file for future use in production. The max value for local and staging are set to 2 to keep unnecessary scaling to a minimum while also enabling us to see the effect.

It is set to 5 for production because this gives some headroom above the currently defined 3.

## This is what I need help with
No particular help needed just a general eye for mistakes.
I'd also happily hear feedback on the max values.

Bug: T368360
