### PR TITLE
fix(superset chart): Remove invalid SecurityContext

### DIFF
--- a/charts/superset/templates/statefulset.yaml
+++ b/charts/superset/templates/statefulset.yaml
@@ -27,8 +27,7 @@ spec:
         {{- toYaml .Values.securityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
+          securityContext: {}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
## Describe the changes
The SecurityContext spec cannot contain fsGroup and fsGroupChanngePolicy as per the api reference[1]

This only seems to be an issue on some developers
machines but it prevents deploying code.

Given that this is invalid k8s yaml it would be better removed

[1] - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.30/#securitycontext-v1-core

## This is what I need help with
If anyone has any more ideas about *why* some developers' setups happily ingest this invalid spec I'd be interested to hear.

### Prior discussion
We talked about this in person at some length during the team week on the afternoon of 2024-07-10
