### PR TITLE
production feat(mediawiki): add HPA for web

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -167,7 +167,7 @@ releases:
   - name: mediawiki-139
     namespace: default
     chart: wbstack/mediawiki
-    version: '{{ if eq .Environment.Name "production" }}0.11.2{{ else }}0.12.0{{ end }}'
+    version: 0.12.0
     <<: *default_release
 
   - name: queryservice-ui


### PR DESCRIPTION
## Describe the changes
As a follow up to #1704 this enables using the new MW chart with an HPA for production.

## This is what I need help with
Nothing but a quick glance for a mistake

Bug: T368360