### PR TITLE
generate-values: don't use relative path for helmfile

### DIFF
--- a/bin/generate-values
+++ b/bin/generate-values
@@ -12,7 +12,7 @@ RELEASE="$2"
 # absolute path of the wbaas-deploy repository
 ROOT=$(realpath $(dirname $(realpath $BASH_SOURCE))/..)
 OUTPUT_TEMPLATE="${ROOT}/k8s/argocd/${ENVIRONMENT}/${RELEASE}.values.yaml"
-HELMFILE="k8s/helmfile/helmfile.yaml"
+HELMFILE="${ROOT}/k8s/helmfile/helmfile.yaml"
 TMP_HELMFILE="$(dirname ${HELMFILE})/.tmp_helmfile.$(mktemp -u XXXXXX).yaml"
 
 if [[ -n "$3" ]]; then


### PR DESCRIPTION
## Describe the changes
We think that this fails when running from a place other than the root of this repo.

We saw it error with `error: helmfile not found: 'k8s/helmfile/helmfile.yaml'` when trying to call this from and action in the ui repo.

### Prior discussion
Pair programmed with @deer-wmde 
