### PR TITLE
.tool-versions: bump opentofu version

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 kubectl 1.28.9
 minikube 1.31.1
-opentofu 1.6.2
+opentofu 1.8.1
 helm 3.12.2 
 helmfile 0.162.0
 skaffold 2.9.0 


### PR DESCRIPTION
we noticed problems when running different opentofu versions so here is the new recommended version we should use
