### PR TITLE
argo: anonymous read-only access

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -8,6 +8,7 @@ dex:
 
 configs:
   cm:
+    users.anonymous.enabled: true
     admin.enabled: false
 
     ui.bannerpermanent: true
@@ -22,6 +23,20 @@ configs:
           color:white;
         }
     }
+
+  rbac:
+    "policy.default": "role:unauthenticated"
+    "policy.csv": |
+        g, anonymous, role:unauthenticated
+        p, role:unauthenticated, applications, get, */*, allow
+        p, role:unauthenticated, clusters, get, */*, allow
+        p, role:unauthenticated, projects, get, *, allow
+        p, role:unauthenticated, repositories, get, *, allow
+        p, role:unauthenticated, repositories, list, *, allow
+        p, role:unauthenticated, repositories, validate, *, allow
+        p, role:unauthenticated, accounts, get, *, allow
+        p, role:unauthenticated, certificates, get, *, allow
+        p, role:unauthenticated, gpgkeys, get, *, allow
 
 controller:
   resources:


### PR DESCRIPTION
In order to make wbcloud lives easier I configured a read-only access for ArgoCD where you do not need to log in in order to inspect argo resources with its ui.

I'm not sure I did this right, but it seems to do the trick. Here are some docs: https://github.com/argoproj/argo-cd/blob/master/docs/operator-manual/rbac.md
