### PR TITLE
local new-cluster script: add command for running initial migrations

### DIFF
--- a/bin/local/new-local-cluster.sh
+++ b/bin/local/new-local-cluster.sh
@@ -38,6 +38,10 @@ set -e
 sleep 60
 helmfile --environment local sync
 
+# run initial database migrations in case the pre-install-job failed for some reason
+# https://github.com/wbstack/charts/blob/main/charts/api/templates/pre-install-job.yaml#L39
+kubectl exec -ti deployments/api-app-backend -- bash -c 'php artisan migrate:install; php artisan migrate --force; php artisan passport:client --personal --no-interaction; php artisan passport:client --password --no-interaction'
+
 echo
 echo "Finished re-initializing local cluster."
 echo "To also create a local user account, open the minikube tunnel and run './bin/local/create-local-user.sh'."


### PR DESCRIPTION
Sometimes when initializing a new local cluster it can happen that the artisan pre-install job fails. We should probably fix the Backoff limit of that job or something but for now I'll put this here to save us some time, because that's what this script is there for