### PR TITLE
Change scorecard values for total item and properties from 50th percentile to Mean

### DIFF
--- a/tf/env/production/platform-summary-dashboard-json.json
+++ b/tf/env/production/platform-summary-dashboard-json.json
@@ -487,8 +487,8 @@
                 "filter": "metric.type=\"logging.googleapis.com/user/wbaas-3-platform-summary-total_items_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "crossSeriesReducer": "REDUCE_MEAN",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_DELTA",
+                  "crossSeriesReducer": "REDUCE_MEAN"
                 }
               }
             }
@@ -508,8 +508,8 @@
                 "filter": "metric.type=\"logging.googleapis.com/user/wbaas-3-platform-summary-total_properties_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "crossSeriesReducer": "REDUCE_MEAN",
-                  "perSeriesAligner": "ALIGN_DELTA"
+                  "perSeriesAligner": "ALIGN_DELTA",
+                  "crossSeriesReducer": "REDUCE_MEAN"
                 }
               }
             }

--- a/tf/env/production/platform-summary-dashboard-json.json
+++ b/tf/env/production/platform-summary-dashboard-json.json
@@ -487,8 +487,8 @@
                 "filter": "metric.type=\"logging.googleapis.com/user/wbaas-3-platform-summary-total_items_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "perSeriesAligner": "ALIGN_DELTA",
-                  "crossSeriesReducer": "REDUCE_PERCENTILE_50"
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_DELTA"
                 }
               }
             }
@@ -508,8 +508,8 @@
                 "filter": "metric.type=\"logging.googleapis.com/user/wbaas-3-platform-summary-total_properties_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "perSeriesAligner": "ALIGN_DELTA",
-                  "crossSeriesReducer": "REDUCE_PERCENTILE_50"
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "perSeriesAligner": "ALIGN_DELTA"
                 }
               }
             }

--- a/tf/env/staging/platform-summary-dashboard-json.json
+++ b/tf/env/staging/platform-summary-dashboard-json.json
@@ -521,7 +521,6 @@
                 "aggregation": {
                   "alignmentPeriod": "86400s",
                   "crossSeriesReducer": "REDUCE_MEAN",
-                  "groupByFields": [],
                   "perSeriesAligner": "ALIGN_DELTA"
                 },
                 "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_items_count\" resource.type=\"k8s_container\""
@@ -543,7 +542,6 @@
                 "aggregation": {
                   "alignmentPeriod": "86400s",
                   "crossSeriesReducer": "REDUCE_MEAN",
-                  "groupByFields": [],
                   "perSeriesAligner": "ALIGN_DELTA"
                 },
                 "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_properties_count\" resource.type=\"k8s_container\""

--- a/tf/env/staging/platform-summary-dashboard-json.json
+++ b/tf/env/staging/platform-summary-dashboard-json.json
@@ -372,11 +372,11 @@
               "label": "y1Axis",
               "scale": "LINEAR"
             },
-            "y2Axis": {
-              "scale": "LINEAR"
-            },
             "chartOptions": {
               "mode": "COLOR"
+            },
+            "y2Axis": {
+              "scale": "LINEAR"
             }
           }
         }
@@ -484,12 +484,12 @@
           "scorecard": {
             "timeSeriesQuery": {
               "timeSeriesFilter": {
+                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_items_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "crossSeriesReducer": "REDUCE_MEAN",
-                  "perSeriesAligner": "ALIGN_DELTA"
-                },
-                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_items_count\" resource.type=\"k8s_container\""
+                  "perSeriesAligner": "ALIGN_DELTA",
+                  "crossSeriesReducer": "REDUCE_MEAN"
+                }
               }
             }
           }
@@ -505,12 +505,12 @@
           "scorecard": {
             "timeSeriesQuery": {
               "timeSeriesFilter": {
+                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_properties_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "crossSeriesReducer": "REDUCE_MEAN",
-                  "perSeriesAligner": "ALIGN_DELTA"
-                },
-                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_properties_count\" resource.type=\"k8s_container\""
+                  "perSeriesAligner": "ALIGN_DELTA",
+                  "crossSeriesReducer": "REDUCE_MEAN"
+                }
               }
             }
           }

--- a/tf/env/staging/platform-summary-dashboard-json.json
+++ b/tf/env/staging/platform-summary-dashboard-json.json
@@ -221,9 +221,11 @@
               "horizontalAlignment": "H_LEFT",
               "verticalAlignment": "V_TOP",
               "padding": "P_EXTRA_SMALL",
-              "fontSize": "FS_LARGE"
+              "fontSize": "FS_LARGE",
+              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED"
             }
-          }
+          },
+          "id": ""
         }
       },
       {
@@ -302,11 +304,18 @@
                 "aggregation": {
                   "alignmentPeriod": "86400s",
                   "perSeriesAligner": "ALIGN_DELTA",
-                  "crossSeriesReducer": "REDUCE_MEAN"
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "groupByFields": []
                 }
-              }
-            }
-          }
+              },
+              "unitOverride": "",
+              "outputFullDuration": false
+            },
+            "thresholds": [],
+            "dimensions": [],
+            "measures": []
+          },
+          "id": ""
         }
       },
       {
@@ -325,14 +334,20 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN"
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": []
                     }
-                  }
+                  },
+                  "unitOverride": "",
+                  "outputFullDuration": false
                 },
                 "plotType": "LINE",
                 "legendTemplate": "Total non-deleted active users",
                 "minAlignmentPeriod": "86400s",
-                "targetAxis": "Y2"
+                "targetAxis": "Y2",
+                "dimensions": [],
+                "measures": [],
+                "breakdowns": []
               },
               {
                 "timeSeriesQuery": {
@@ -341,14 +356,20 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN"
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": []
                     }
-                  }
+                  },
+                  "unitOverride": "",
+                  "outputFullDuration": false
                 },
                 "plotType": "LINE",
                 "legendTemplate": "Total non-deleted users",
                 "minAlignmentPeriod": "86400s",
-                "targetAxis": "Y2"
+                "targetAxis": "Y2",
+                "dimensions": [],
+                "measures": [],
+                "breakdowns": []
               },
               {
                 "timeSeriesQuery": {
@@ -357,26 +378,36 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN"
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": []
                     }
-                  }
+                  },
+                  "unitOverride": "",
+                  "outputFullDuration": false
                 },
                 "plotType": "LINE",
                 "legendTemplate": "Total non-deleted edits",
                 "minAlignmentPeriod": "86400s",
-                "targetAxis": "Y1"
+                "targetAxis": "Y1",
+                "dimensions": [],
+                "measures": [],
+                "breakdowns": []
               }
             ],
             "timeshiftDuration": "0s",
+            "thresholds": [],
             "yAxis": {
               "label": "y1Axis",
               "scale": "LINEAR"
             },
-            "chartOptions": {
-              "mode": "COLOR"
-            },
             "y2Axis": {
+              "label": "",
               "scale": "LINEAR"
+            },
+            "chartOptions": {
+              "mode": "COLOR",
+              "showLegend": false,
+              "displayHorizontal": false
             }
           }
         }
@@ -397,7 +428,8 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN"
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": []
                     }
                   }
                 },
@@ -413,7 +445,8 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN"
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": []
                     }
                   }
                 },
@@ -429,7 +462,8 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN"
+                      "crossSeriesReducer": "REDUCE_MEAN",
+                      "groupByFields": []
                     }
                   }
                 },
@@ -484,12 +518,13 @@
           "scorecard": {
             "timeSeriesQuery": {
               "timeSeriesFilter": {
-                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_items_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "perSeriesAligner": "ALIGN_DELTA",
-                  "crossSeriesReducer": "REDUCE_PERCENTILE_50"
-                }
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_DELTA"
+                },
+                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_items_count\" resource.type=\"k8s_container\""
               }
             }
           }
@@ -505,12 +540,13 @@
           "scorecard": {
             "timeSeriesQuery": {
               "timeSeriesFilter": {
-                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_properties_count\" resource.type=\"k8s_container\"",
                 "aggregation": {
                   "alignmentPeriod": "86400s",
-                  "perSeriesAligner": "ALIGN_DELTA",
-                  "crossSeriesReducer": "REDUCE_PERCENTILE_50"
-                }
+                  "crossSeriesReducer": "REDUCE_MEAN",
+                  "groupByFields": [],
+                  "perSeriesAligner": "ALIGN_DELTA"
+                },
+                "filter": "metric.type=\"logging.googleapis.com/user/wbaas-2-platform-summary-total_properties_count\" resource.type=\"k8s_container\""
               }
             }
           }

--- a/tf/env/staging/platform-summary-dashboard-json.json
+++ b/tf/env/staging/platform-summary-dashboard-json.json
@@ -221,11 +221,9 @@
               "horizontalAlignment": "H_LEFT",
               "verticalAlignment": "V_TOP",
               "padding": "P_EXTRA_SMALL",
-              "fontSize": "FS_LARGE",
-              "pointerLocation": "POINTER_LOCATION_UNSPECIFIED"
+              "fontSize": "FS_LARGE"
             }
-          },
-          "id": ""
+          }
         }
       },
       {
@@ -304,18 +302,11 @@
                 "aggregation": {
                   "alignmentPeriod": "86400s",
                   "perSeriesAligner": "ALIGN_DELTA",
-                  "crossSeriesReducer": "REDUCE_MEAN",
-                  "groupByFields": []
+                  "crossSeriesReducer": "REDUCE_MEAN"
                 }
-              },
-              "unitOverride": "",
-              "outputFullDuration": false
-            },
-            "thresholds": [],
-            "dimensions": [],
-            "measures": []
-          },
-          "id": ""
+              }
+            }
+          }
         }
       },
       {
@@ -334,20 +325,14 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN",
-                      "groupByFields": []
+                      "crossSeriesReducer": "REDUCE_MEAN"
                     }
-                  },
-                  "unitOverride": "",
-                  "outputFullDuration": false
+                  }
                 },
                 "plotType": "LINE",
                 "legendTemplate": "Total non-deleted active users",
                 "minAlignmentPeriod": "86400s",
-                "targetAxis": "Y2",
-                "dimensions": [],
-                "measures": [],
-                "breakdowns": []
+                "targetAxis": "Y2"
               },
               {
                 "timeSeriesQuery": {
@@ -356,20 +341,14 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN",
-                      "groupByFields": []
+                      "crossSeriesReducer": "REDUCE_MEAN"
                     }
-                  },
-                  "unitOverride": "",
-                  "outputFullDuration": false
+                  }
                 },
                 "plotType": "LINE",
                 "legendTemplate": "Total non-deleted users",
                 "minAlignmentPeriod": "86400s",
-                "targetAxis": "Y2",
-                "dimensions": [],
-                "measures": [],
-                "breakdowns": []
+                "targetAxis": "Y2"
               },
               {
                 "timeSeriesQuery": {
@@ -378,36 +357,26 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN",
-                      "groupByFields": []
+                      "crossSeriesReducer": "REDUCE_MEAN"
                     }
-                  },
-                  "unitOverride": "",
-                  "outputFullDuration": false
+                  }
                 },
                 "plotType": "LINE",
                 "legendTemplate": "Total non-deleted edits",
                 "minAlignmentPeriod": "86400s",
-                "targetAxis": "Y1",
-                "dimensions": [],
-                "measures": [],
-                "breakdowns": []
+                "targetAxis": "Y1"
               }
             ],
             "timeshiftDuration": "0s",
-            "thresholds": [],
             "yAxis": {
               "label": "y1Axis",
               "scale": "LINEAR"
             },
             "y2Axis": {
-              "label": "",
               "scale": "LINEAR"
             },
             "chartOptions": {
-              "mode": "COLOR",
-              "showLegend": false,
-              "displayHorizontal": false
+              "mode": "COLOR"
             }
           }
         }
@@ -428,8 +397,7 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN",
-                      "groupByFields": []
+                      "crossSeriesReducer": "REDUCE_MEAN"
                     }
                   }
                 },
@@ -445,8 +413,7 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN",
-                      "groupByFields": []
+                      "crossSeriesReducer": "REDUCE_MEAN"
                     }
                   }
                 },
@@ -462,8 +429,7 @@
                     "aggregation": {
                       "alignmentPeriod": "86400s",
                       "perSeriesAligner": "ALIGN_DELTA",
-                      "crossSeriesReducer": "REDUCE_MEAN",
-                      "groupByFields": []
+                      "crossSeriesReducer": "REDUCE_MEAN"
                     }
                   }
                 },


### PR DESCRIPTION
## Describe the changes

		1. On the Platform Summary dashboard in Google Cloud the scorecards total items and total properties
		are configured to 50th percentile instead of Mean and therefore show incorrect numbers not matching the charts ?
		2. I made the change on the google cloud dashboard and downloaded the json with
		which I then updated these files?

## This is what I need help with

	Please confirm this has no bomb in it and can be deployed to production.

## Link to Phabricator
https://phabricator.wikimedia.org/T369347

