### PR TITLE
Bump table_open_cache and table_definition_cache

### DIFF
--- a/k8s/helmfile/env/local/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/sql.values.yaml.gotmpl
@@ -44,8 +44,8 @@ primary:
     max_binlog_size=107374182
 
     # T348842
-    table_open_cache=4096
-    table_definition_cache=4096
+    table_open_cache=5120
+    table_definition_cache=5120
 
     [mysql]
     # https://forums.mysql.com/read.php?103,189835,192421#msg-192421

--- a/k8s/helmfile/env/local/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/sql.values.yaml.gotmpl
@@ -43,7 +43,7 @@ primary:
     # 100MB, default & bitnami was 1GB (1073741824)
     max_binlog_size=107374182
 
-    # T348842
+    # T373448
     table_open_cache=5120
     table_definition_cache=5120
 

--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -46,9 +46,9 @@ primary:
     # 100MB, default & bitnami was 1GB (1073741824)
     max_binlog_size=107374182
 
-    # T348842
-    table_open_cache=4096
-    table_definition_cache=4096
+    # T373448
+    table_open_cache=5120
+    table_definition_cache=5120
 
     [mysql]
     # https://forums.mysql.com/read.php?103,189835,192421#msg-192421

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -37,8 +37,8 @@ primary:
     max_binlog_size=107374182
 
     # T348842
-    table_open_cache=4096
-    table_definition_cache=4096
+    table_open_cache=5120
+    table_definition_cache=5120
 
     [mysql]
     # https://forums.mysql.com/read.php?103,189835,192421#msg-192421

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -36,7 +36,7 @@ primary:
     # 100MB, default & bitnami was 1GB (1073741824)
     max_binlog_size=107374182
 
-    # T348842
+    # T373448
     table_open_cache=5120
     table_definition_cache=5120
 


### PR DESCRIPTION
<!--
	Please populate this Pull Request template for **every** pull request
	unless there is a really good reason against it. Your reviewer as well
	as your future self will be thankful for the context given.

	If you have specific code level changes to discuss, it's also helpful to
	leave comments about your concerns at line level before requesting review.
-->

## Describe the changes

We bumped `table_open_cache` and `table_definition_cache`. Reasons:
- We think the `PlatformStatsSummaryJob` from the `api` opens many tables. The more wikis, the more tables are opened so as the wikis number grows, we need more room for tables to be opened at the same time.
- We think this number should be >3 times the number of wikis (incl. deleted wikis).
- So we should now have around 300 wikis headroom.

<!--
	To help reviewers with understanding the changes at hand, provide a
	short summary of:
		1. why is this change needed?
		2. what led to choosing the current implementation?
		3. are there any alternative solutions you considered, but did not
           pursue further?
-->

## This is what I need help with

- Just try and see if it fixes the problem

<!--
	Help the reviewer understand what you are looking for in the review. Are
	there certain parts of the code you are unsure about? Is there anything that
	should **not** be reviewed yet? To which extent did you already perform QA
	on this change?
-->

### Prior discussion

- Paired with @tarrow and @deer-wmde on this topic.
<!--
	Has there been any in person discussion about this PR that led to the
	current implementation, and which is not documented in the Phabricator
	ticket? In case yes, please provide context about this for the reviewer.
	Feel free to @mention the people involved in the discussion.
-->

Bug: T373448
