### PR TITLE
staging: platform-nginx route PMs wiki to alpha mediawiki

### DIFF
--- a/k8s/helmfile/env/staging/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/staging/platform-nginx.nginx.conf
@@ -70,6 +70,11 @@ server {
                 set $mwgroup "alpha";
         }
 
+        # Allowoverriding the group decision for special wikis
+        if ($host = "anton2.wikibase.dev") {
+                set $mwgroup "alpha";
+        }
+
         ############# Locations #############
 
         location = /kube-probe {


### PR DESCRIPTION
<!--
	Please populate this Pull Request template for **every** pull request
	unless there is a really good reason against it. Your reviewer as well
	as your future self will be thankful for the context given.

	If you have specific code level changes to discuss, it's also helpful to
	leave comments about your concerns at line level before requesting review.
-->

## Describe the changes
This change routes all wiki traffic that goes to the platform-nginx for https://anton2.wikibase.dev/ to the alpha mediawiki deployment.

This allows us to push specific images there for unusual/dangerous configurations.

Right now there is are no values change in git for this unusual configuration and they are being managed by manually altering the images that are present.

<!--
	To help reviewers with understanding the changes at hand, provide a
	short summary of:
		1. why is this change needed?
		2. what led to choosing the current implementation?
		3. are there any alternative solutions you considered, but did not
           pursue further?
-->

## This is what I need help with
Currently being tried under "dibs" on staging. You could check that this is indeed working as expected by confirming that traffic is going to the alpha wiki.
<!--
	Help the reviewer understand what you are looking for in the review. Are
	there certain parts of the code you are unsure about? Is there anything that
	should **not** be reviewed yet? To which extent did you already perform QA
	on this change?
-->

### Prior discussion
Almost none, let me know what you think @rosalieper 

<!--
	Has there been any in person discussion about this PR that led to the
	current implementation, and which is not documented in the Phabricator
	ticket? In case yes, please provide context about this for the reviewer.
	Feel free to @mention the people involved in the discussion.
-->


Bug: T374336