### PR TITLE
helmfile: remove `installed: false` for ui

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -168,7 +168,6 @@ releases:
     <<: *default_release
 
   - name: ui
-    installed: false
     namespace: default
     chart: wbstack/ui
     version: 0.3.1


### PR DESCRIPTION
For some reason I thought we need to set this to `installed: false` in order to stop helmfile from redeploying this in case argocd is doing the deployment. That assumption seems to be false though.

We could also get rid of this part of the `generate-values` script then, but on the other hand it also doesn't harm us: https://github.com/wmde/wbaas-deploy/blob/e82d4703717c8b16ca03f21110c2561835646088/bin/generate-values#L47-L50
