### PR TITLE
argocd: fix environment banner

### DIFF
--- a/k8s/helmfile/env/local/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/argo-cd-base.values.yaml.gotmpl
@@ -6,7 +6,7 @@ configs:
     admin.enabled: "true"
 
     ui.bannercontent: "LOCAL"
-    ui.bannerurl: "http://wikibase.localhost"
+    ui.bannerurl: "http://www.wbaas.localhost/"
 
   styles: |
     .ui-banner {

--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -12,6 +12,7 @@ configs:
     admin.enabled: false
 
     ui.bannerpermanent: true
+    ui.bannerposition: "top"
     ui.bannercontent: "PRODUCTION"
     ui.bannerurl: "https://wikibase.cloud/"
 


### PR DESCRIPTION
A while ago I configured different banners for the different environment argocd runs in. For some reason it stopped working some time, now I found the reason (and I fixed the URL for local env)

![image](https://github.com/user-attachments/assets/4ef6c03d-69a9-4a68-88ed-78f286a3091b)
![image](https://github.com/user-attachments/assets/cba39f32-dcfc-4b79-ab99-d1b49b213d1e)
![image](https://github.com/user-attachments/assets/a3327448-1520-4db6-906b-2514768bb21b)
