### PR TITLE
production: reduce general platform nginx to 10s

### DIFF
--- a/k8s/helmfile/env/production/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/production/platform-nginx.nginx.conf
@@ -56,8 +56,8 @@ server {
 
         # Custom headers to proxied server
         proxy_connect_timeout                   5s;
-        proxy_send_timeout                      60s;
-        proxy_read_timeout                      60s;
+        proxy_send_timeout                      10s;
+        proxy_read_timeout                      10s;
 
         proxy_buffering                         off;
         proxy_buffer_size                       4k;


### PR DESCRIPTION
n.b. this doesn't impact queryservice

We want to try this in order to see if it stops what appears to be cascading outages.

Paired with @deer-wmde on this.

Bug: T375866
