### PR TITLE
Revert "production: reduce general platform nginx to 10s"

### DIFF
--- a/k8s/helmfile/env/production/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/production/platform-nginx.nginx.conf
@@ -56,8 +56,8 @@ server {
 
         # Custom headers to proxied server
         proxy_connect_timeout                   5s;
-        proxy_send_timeout                      10s;
-        proxy_read_timeout                      10s;
+        proxy_send_timeout                      60s;
+        proxy_read_timeout                      60s;
 
         proxy_buffering                         off;
         proxy_buffer_size                       4k;


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1787
https://phabricator.wikimedia.org/T375866
This seems to make things worse or at least doesnt help much, appearantly