### PR TITLE
lift cpu limits for mediawiki resources

### DIFF
--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -59,26 +59,26 @@ resources:
       cpu: 500m
       memory: 1600Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 2800Mi
   webapi:
     requests:
       cpu: 200m
       memory: 250Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 600Mi
   backend:
     requests:
       cpu: 500m
       memory: 600Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 1200Mi

--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -59,26 +59,26 @@ resources:
       cpu: 500m
       memory: 1600Mi
     limits:
-      cpu: '1'
+      cpu: 0
       memory: 2800Mi
   webapi:
     requests:
       cpu: 200m
       memory: 250Mi
     limits:
-      cpu: 500m
+      cpu: 0
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: 500m
+      cpu: 0
       memory: 600Mi
   backend:
     requests:
       cpu: 500m
       memory: 600Mi
     limits:
-      cpu: 1000m
+      cpu: 0
       memory: 1200Mi

--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -23,26 +23,26 @@ resources:
       cpu: 100m
       memory: 250Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 750Mi
   webapi:
     requests:
       cpu: 100m
       memory: 125Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 600Mi
   backend:
     requests:
       cpu: 125m
       memory: 200Mi
     limits:
-      cpu: 0
+      cpu: null
       memory: 1200Mi

--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -23,26 +23,26 @@ resources:
       cpu: 100m
       memory: 250Mi
     limits:
-      cpu: 400m
+      cpu: 0
       memory: 750Mi
   webapi:
     requests:
       cpu: 100m
       memory: 125Mi
     limits:
-      cpu: 500m
+      cpu: 0
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: 500m
+      cpu: 0
       memory: 600Mi
   backend:
     requests:
       cpu: 125m
       memory: 200Mi
     limits:
-      cpu: 1000m
+      cpu: 0
       memory: 1200Mi


### PR DESCRIPTION
https://phabricator.wikimedia.org/T375874

as a first step we only lift cpu limits for mw resources and will observe the effect

