### PR TITLE
chore(tf): add compute-pool-2 on staging

### DIFF
--- a/tf/env/staging/cluster.tf
+++ b/tf/env/staging/cluster.tf
@@ -54,3 +54,38 @@ resource "google_container_node_pool" "wbaas-2_compute-pool-1" {
     max_unavailable = 0
   }
 }
+
+resource "google_container_node_pool" "wbaas-2_compute-pool-2" {
+  cluster    = "wbaas-2"
+  name       = "compute-pool-2"
+  node_count = 3
+  node_locations = [
+    "europe-west3-a",
+  ]
+  node_config {
+    disk_size_gb = 32
+    disk_type    = "pd-ssd"
+    machine_type = "n2-standard-4"
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+    preemptible     = false
+    service_account = "default"
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = false
+    }
+  }
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+}


### PR DESCRIPTION
This commit adds a new node pool to replace the exiting one.
It uses smaller machines to free up some capacity.
The commit removing the existing node pool will happen later.

Bug: T376117