### PR TITLE
chore(argo): increase memory for dex on staging

### DIFF
--- a/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
@@ -1,3 +1,10 @@
+dex:
+  resources:
+    limits:
+      memory: 128Mi
+    requests:
+      memory: 64Mi
+
 configs:
   cm:
     ui.bannercontent: "STAGING"


### PR DESCRIPTION
This increases the memory since we suspect that why it now fails to start.
It was stuck in crashloop backoff exiting with code 139
See: https://github.com/argoproj/argo-cd/issues/15786

Bug: T376117