### PR TITLE
fix: creating local cluster fails on CPU limit

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -103,7 +103,7 @@ replicaCount:
 resources:
   backend:
     limits:
-      cpu: null
+      cpu: 1000m
       memory: 600Mi
     requests:
       cpu: 500m
@@ -117,14 +117,14 @@ resources:
       memory: 256Mi
   scheduler:
     limits:
-      cpu: null
+      cpu: 40m
       memory: 80Mi
     requests:
       cpu: 5m
       memory: 20Mi
   web:
     limits:
-      cpu: null
+      cpu: 250m
       memory: 400Mi
     requests:
       cpu: 100m

--- a/k8s/argocd/local/ui.values.yaml
+++ b/k8s/argocd/local/ui.values.yaml
@@ -15,7 +15,7 @@ podLabels:
   sidecar.istio.io/inject: "true"
 resources:
   limits:
-    cpu: null
+    cpu: 10m
     memory: 20Mi
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -62,6 +62,12 @@ trustedProxy:
   proxies: ['*']
 
 resources:
+  backend:
+    limits:
+      cpu: 1000m
+  web:
+    limits:
+      cpu: 250m
   queue:
     requests:
       cpu: 100m
@@ -69,3 +75,6 @@ resources:
     limits:
       cpu: 250m
       memory: 512Mi
+  scheduler:
+    limits:
+      cpu: 40m

--- a/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
@@ -2,3 +2,6 @@ controller:
   resources:
     limits:
       cpu: 100m
+
+  admissionWebhooks:
+    enabled: false

--- a/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
@@ -1,1 +1,4 @@
-# local matches production
+controller:
+  resources:
+    limits:
+      cpu: 100m

--- a/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/mediawiki-139.values.yaml.gotmpl
@@ -31,3 +31,17 @@ replicaCount:
   web: 1
   webapi: 1
   alpha: 1
+
+resources:
+  web:
+    limits:
+      cpu: 1000m
+  webapi:
+    limits:
+      cpu: 500m
+  alpha:
+    limits:
+      cpu: 500m
+  backend:
+    limits:
+      cpu: 1000m

--- a/k8s/helmfile/env/local/platform-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/platform-nginx.values.yaml.gotmpl
@@ -2,3 +2,7 @@ replicaCount: 1
 
 serverBlock: |-
 {{ readFile "platform-nginx.nginx.conf" | indent 2 }}
+
+resources:
+  limits:
+    cpu: 50m

--- a/k8s/helmfile/env/local/ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ui.values.yaml.gotmpl
@@ -7,3 +7,7 @@ ui:
 
 ingress:
   tls: null
+
+resources:
+  limits:
+    cpu: 10m


### PR DESCRIPTION
Setting up a local cluster from scratch fails on multiple releases with errors similar to the following:

```
Deployment.apps "ingress-nginx-controller" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "100m": must be less than or equal to cpu limit of 0
```

This patch restores previous CPU limits for affected releases.