### PR TITLE
Use api 0.32.0

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -163,7 +163,7 @@ releases:
 
   - name: api
     chart: wbstack/api
-    version: "0.31.2"
+    version: "0.32.0"
     namespace: default
     <<: *default_release
 


### PR DESCRIPTION
Update api chart version for all environment

Link to Phabricator
Bug: [T375268](https://phabricator.wikimedia.org/T375268)