### PR TITLE
Revert "reduce cert manager log level"

### DIFF
--- a/k8s/helmfile/cert-manager.yaml
+++ b/k8s/helmfile/cert-manager.yaml
@@ -26,5 +26,3 @@ releases:
     set:
       - name: installCRDs
         value: true
-      - name: global.logLevel
-        value: 1


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#1804

This didn't have the impact we were expecting on staging. There were still a large amount of pointless-ish looking logs