### PR TITLE
update argo to 2.12.5

### DIFF
--- a/k8s/helmfile/argo-cd.yaml
+++ b/k8s/helmfile/argo-cd.yaml
@@ -25,5 +25,5 @@ releases:
   - name: argo-cd-base
     namespace: argocd
     chart: argo-cd/argo-cd
-    version: '6.7.15'
+    version: '7.6.11'
     <<: *default_release

--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -97,7 +97,7 @@ server:
   resources:
    limits:
      cpu: 100m
-     memory: 128Mi
+     memory: 512Mi
    requests:
      cpu: 50m
-     memory: 64Mi
+     memory: 256Mi


### PR DESCRIPTION
This updates argocd from v2.10.7 to v2.12.5

by using chart v7.6.11
https://github.com/argoproj/argo-helm/blob/argo-cd-7.6.11/charts/argo-cd/Chart.yaml

As far as I can see no config adjustments need to happen: https://argo-cd.readthedocs.io/en/stable/operator-manual/upgrading/2.10-2.11/
