### PR TITLE
argo: staging and prod remove null cpu limits

### DIFF
--- a/k8s/argocd/production/ui.values.yaml
+++ b/k8s/argocd/production/ui.values.yaml
@@ -18,7 +18,6 @@ podLabels:
   sidecar.istio.io/inject: "true"
 resources:
   limits:
-    cpu: null
     memory: 20Mi
   requests:
     cpu: 1m

--- a/k8s/argocd/staging/ui.values.yaml
+++ b/k8s/argocd/staging/ui.values.yaml
@@ -18,7 +18,6 @@ podLabels:
   sidecar.istio.io/inject: "true"
 resources:
   limits:
-    cpu: null
     memory: 20Mi
   requests:
     cpu: 1m

--- a/k8s/helmfile/env/production/ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ui.values.yaml.gotmpl
@@ -6,7 +6,6 @@ resources:
     cpu: 1m
     memory: 6Mi
   limits:
-    cpu: null
     memory: 20Mi
 
 ingress:


### PR DESCRIPTION
It appears that null cpu limits don't seem to work well and result in argocd constantly syncing

Instead it is better to totally omit them

This commit will be followed up by one for the API

Bug: T378328

<!--
	Please populate this Pull Request template for **every** pull request
	unless there is a really good reason against it. Your reviewer as well
	as your future self will be thankful for the context given.

	If you have specific code level changes to discuss, it's also helpful to
	leave comments about your concerns at line level before requesting review.
-->


<!--
	To help reviewers with understanding the changes at hand, provide a
	short summary of:
		1. why is this change needed?
		2. what led to choosing the current implementation?
		3. are there any alternative solutions you considered, but did not
           pursue further?
-->


<!--
	Help the reviewer understand what you are looking for in the review. Are
	there certain parts of the code you are unsure about? Is there anything that
	should **not** be reviewed yet? To which extent did you already perform QA
	on this change?
-->



<!--
	Provide a link to the relevant Phabricator ticket for this Pull Request.
	If there is none, try to explain what prompted opening this PR (e.g. adhoc
	resolution of an incident, typo fix or similar).
-->

<!--
	Has there been any in person discussion about this PR that led to the
	current implementation, and which is not documented in the Phabricator
	ticket? In case yes, please provide context about this for the reviewer.
	Feel free to @mention the people involved in the discussion.
-->
