### PR TITLE
argo: api staging and prod remove null cpu limits

### DIFF
--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -104,28 +104,24 @@ replicaCount:
 resources:
   backend:
     limits:
-      cpu: null
       memory: 600Mi
     requests:
       cpu: 500m
       memory: 300Mi
   queue:
     limits:
-      cpu: null
       memory: 1024Mi
     requests:
       cpu: 500m
       memory: 512Mi
   scheduler:
     limits:
-      cpu: null
       memory: 80Mi
     requests:
       cpu: 5m
       memory: 20Mi
   web:
     limits:
-      cpu: null
       memory: 400Mi
     requests:
       cpu: 100m

--- a/k8s/argocd/staging/api.values.yaml
+++ b/k8s/argocd/staging/api.values.yaml
@@ -105,28 +105,24 @@ replicaCount:
 resources:
   backend:
     limits:
-      cpu: null
       memory: 600Mi
     requests:
       cpu: 500m
       memory: 300Mi
   queue:
     limits:
-      cpu: null
       memory: 512Mi
     requests:
       cpu: 100m
       memory: 256Mi
   scheduler:
     limits:
-      cpu: null
       memory: 80Mi
     requests:
       cpu: 5m
       memory: 20Mi
   web:
     limits:
-      cpu: null
       memory: 400Mi
     requests:
       cpu: 100m

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -147,26 +147,22 @@ resources:
       cpu: 500m
       memory: 300Mi
     limits:
-      cpu: null
       memory: 600Mi
   web:
     requests:
       cpu: 100m
       memory: 340Mi
     limits:
-      cpu: null
       memory: 400Mi
   queue:
     requests:
       cpu: 500m
       memory: 512Mi
     limits:
-      cpu: null
       memory: 1024Mi
   scheduler:
     requests:
       cpu: 5m
       memory: 20Mi
     limits:
-      cpu: null
       memory: 80Mi

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -65,5 +65,4 @@ resources:
       cpu: 100m
       memory: 256Mi
     limits:
-      cpu: null
       memory: 512Mi


### PR DESCRIPTION
Also remove null cpu limit from api.

This should allow argo to smoothly sync

Bug: T378328