### PR TITLE
k8s: Remove Argo managed services from helmfile

### DIFF
--- a/bin/generate-values
+++ b/bin/generate-values
@@ -16,7 +16,7 @@ RELEASE="$2"
 # absolute path of the wbaas-deploy repository
 ROOT=$(realpath $(dirname $(realpath $BASH_SOURCE))/..)
 OUTPUT_TEMPLATE="${ROOT}/k8s/argocd/${ENVIRONMENT}/${RELEASE}.values.yaml"
-HELMFILE="k8s/helmfile/helmfile.yaml"
+HELMFILE="k8s/helmfile/only-for-argo-value-generation.yaml"
 TMP_HELMFILE="$(dirname ${HELMFILE})/.tmp_helmfile.$(mktemp -u XXXXXX).yaml"
 
 if [[ -n "$3" ]]; then

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -161,18 +161,6 @@ releases:
       - forceSSL: {{ .Values.forceSSL | toYaml }}
       - tls: {{ .Values.tls | toYaml }}
 
-  - name: api
-    chart: wbstack/api
-    version: "0.32.0"
-    namespace: default
-    <<: *default_release
-
-  - name: ui
-    namespace: default
-    chart: wbstack/ui
-    version: 0.3.1
-    <<: *default_release
-
   - name: mediawiki-139
     namespace: default
     chart: wbstack/mediawiki

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -139,13 +139,6 @@ releases:
     version: 19.10.2
     <<: *default_release
 
-  - name: redis
-    # This is in the default namespace, as the default ns implies staging?
-    namespace: default
-    chart: bitnami/redis
-    version: 17.3.8
-    <<: *default_release
-
   - name: platform-nginx
     namespace: default
     chart: bitnami-legacy/nginx

--- a/k8s/helmfile/only-for-argo-value-generation.yaml
+++ b/k8s/helmfile/only-for-argo-value-generation.yaml
@@ -1,0 +1,61 @@
+repositories:
+  - name: wbstack
+    url: https://wbstack.github.io/charts
+  - name: bitnami
+    url: https://charts.bitnami.com/bitnami
+  - name: bitnami-legacy
+    # yamllint disable-line rule:line-length
+    url: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+  - name: cetic
+    url: https://cetic.github.io/helm-charts
+  - name: codecentric
+    url: https://codecentric.github.io/helm-charts
+  - name: ingress-nginx
+    url: https://kubernetes.github.io/ingress-nginx
+  - name: prometheus-community
+    url: https://prometheus-community.github.io/helm-charts
+  - name: istio
+    url: https://istio-release.storage.googleapis.com/charts
+  - name: minio
+    url: https://charts.min.io
+
+environments:
+  default:
+    kubeContext: INVALID-ENVIRONMENT
+  production:
+    kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-3
+    values:
+      - ./env/production/base.yaml
+      - ./env/production/private.yaml
+  staging:
+    kubeContext: gke_wikibase-cloud_europe-west3-a_wbaas-2
+    values:
+      - ./env/staging/base.yaml
+      - ./env/staging/private.yaml
+  local:
+    kubeContext: minikube-wbaas
+    values:
+      - ./env/local/base.yaml
+      - ./env/local/private.yaml
+
+---
+
+templates:
+  default: &default_release
+    missingFileHandler: Error
+    values:
+      - env/production/{{`{{ .Release.Name }}`}}.values.yaml.gotmpl
+      - env/{{`{{ .Environment.Name }}`}}/{{`{{ .Release.Name }}`}}.values.yaml.gotmpl
+
+releases:
+  - name: api
+    chart: wbstack/api
+    version: "0.32.0"
+    namespace: default
+    <<: *default_release
+
+  - name: ui
+    namespace: default
+    chart: wbstack/ui
+    version: 0.3.1
+    <<: *default_release

--- a/k8s/helmfile/only-for-argo-value-generation.yaml
+++ b/k8s/helmfile/only-for-argo-value-generation.yaml
@@ -59,3 +59,9 @@ releases:
     chart: wbstack/ui
     version: 0.3.1
     <<: *default_release
+
+  - name: redis
+    namespace: default
+    chart: bitnami/redis
+    version: 17.3.8
+    <<: *default_release


### PR DESCRIPTION
This commit seeks to remove services that are now fully migrated to argo from the main helmfile.yaml.

This should prevent running `make apply` from showing phantom diffs where argo has already enacted the change but helm hasn't yet recorded that change in its secrets.

The github actions reference `generate-values`  and not the specific helmfile yaml so this patch should not require any updates to either [check-generated-values](https://github.com/wmde/wbaas-deploy/blob/main/.github/workflows/check-generated-values.yml) or the image bumping scripts from [api](https://github.com/wbstack/api/blob/main/.github/workflows/docker.build.yml#L88) or [ui](https://github.com/wbstack/ui/blob/main/.github/workflows/docker.build.yml#L80).

