### PR TITLE
helmfile: remove null cpu limits

### DIFF
--- a/k8s/argocd/production/redis.values.yaml
+++ b/k8s/argocd/production/redis.values.yaml
@@ -43,7 +43,6 @@ replica:
   replicaCount: 1
   resources:
     limits:
-      cpu: null
       memory: 250Mi
     requests:
       cpu: 500m

--- a/k8s/argocd/staging/redis.values.yaml
+++ b/k8s/argocd/staging/redis.values.yaml
@@ -43,7 +43,6 @@ replica:
   replicaCount: 1
   resources:
     limits:
-      cpu: null
       memory: 250Mi
     requests:
       cpu: 500m

--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -42,7 +42,6 @@ configs:
 controller:
   resources:
    limits:
-     cpu: null
      memory: 512Mi
    requests:
      cpu: 250m
@@ -51,7 +50,6 @@ controller:
 applicationSet:
   resources:
     limits:
-      cpu: null
       memory: 128Mi
     requests:
       cpu: 100m
@@ -60,7 +58,6 @@ applicationSet:
 dex:
   resources:
    limits:
-     cpu: null
      memory: 64Mi
    requests:
      cpu: 10m
@@ -69,7 +66,6 @@ dex:
 notifications:
   resources:
     limits:
-      cpu: null
       memory: 128Mi
     requests:
       cpu: 100m
@@ -78,7 +74,6 @@ notifications:
 redis:
   resources:
    limits:
-     cpu: null
      memory: 128Mi
    requests:
      cpu: 100m
@@ -87,7 +82,6 @@ redis:
 repoServer:
   resources:
    limits:
-     cpu: null
      memory: 1024Mi
    requests:
      cpu: 10m

--- a/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
@@ -19,7 +19,6 @@ master:
       cpu: "2000m"
       memory: "8Gi"
     limits:
-      cpu: null
       memory: "8Gi"
   persistence:
     enabled: true
@@ -43,7 +42,6 @@ data:
       cpu: "2000m"
       memory: "18Gi"
     limits:
-      cpu: null
       memory: "18Gi"
   persistence:
     enabled: true

--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -7,8 +7,6 @@ controller:
     requests:
       cpu: 0.100
       memory: 150Mi
-    limits:
-      cpu: null
   config:
     custom-http-errors: "502,503"
     preserve-trailing-slash: true

--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -59,26 +59,22 @@ resources:
       cpu: 500m
       memory: 1600Mi
     limits:
-      cpu: null
       memory: 2800Mi
   webapi:
     requests:
       cpu: 200m
       memory: 250Mi
     limits:
-      cpu: null
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: null
       memory: 600Mi
   backend:
     requests:
       cpu: 500m
       memory: 600Mi
     limits:
-      cpu: null
       memory: 1200Mi

--- a/k8s/helmfile/env/production/platform-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/platform-nginx.values.yaml.gotmpl
@@ -2,7 +2,6 @@ replicaCount: 3
 
 resources:
   limits:
-    cpu: null
     memory: 20Mi
   requests:
      cpu: 20m

--- a/k8s/helmfile/env/production/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-gateway.values.yaml.gotmpl
@@ -11,5 +11,4 @@ resources:
     cpu: 125m
     memory: 128Mi
   limits:
-    cpu: null
     memory: 256Mi

--- a/k8s/helmfile/env/production/queryservice-ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-ui.values.yaml.gotmpl
@@ -8,5 +8,4 @@ resources:
     cpu: 1m
     memory: 10Mi
   limits:
-    cpu: null
     memory: 25Mi

--- a/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
@@ -19,5 +19,4 @@ resources:
     cpu: 80m
     memory: 256Mi
   limits:
-    cpu: null
     memory: 512Mi

--- a/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
@@ -11,7 +11,6 @@ resources:
     cpu: 0.5
     memory: "3048Mi"
   limits:
-    cpu: null
     memory: "4072Mi"
 
 persistence:

--- a/k8s/helmfile/env/production/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/redis.values.yaml.gotmpl
@@ -43,7 +43,6 @@ replica:
       cpu: 500m
       memory: 250Mi
     limits:
-      cpu: null
       memory: 250Mi
 
 commonConfiguration: |

--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -10,7 +10,6 @@ primary:
       cpu: '2'
       memory: 8Gi
     limits:
-      cpu: null
       memory: 8Gi
   persistence:
     enabled: true
@@ -74,7 +73,6 @@ secondary:
       cpu: '2'
       memory: 8Gi
     limits:
-      cpu: null
       memory: 8Gi
   readinessProbe:
     enabled: true

--- a/k8s/helmfile/env/production/superset.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/superset.values.yaml.gotmpl
@@ -9,5 +9,4 @@ resources:
     cpu: 500m
     memory: 8Gi
   limits:
-    cpu: null
     memory: 8Gi

--- a/k8s/helmfile/env/production/tool-cradle.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-cradle.values.yaml.gotmpl
@@ -8,7 +8,6 @@ resources:
     cpu: 1m
     memory: 20Mi
   limits:
-    cpu: null
     memory: 60Mi
 
 replicaCount: 1

--- a/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
@@ -21,5 +21,4 @@ resources:
     cpu: 1m
     memory: 40Mi
   limits:
-    cpu: null
     memory: 100Mi

--- a/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
@@ -11,7 +11,6 @@ resources:
     cpu: 1m
     memory: 18Mi
   limits:
-    cpu: null
     memory: 50Mi
 
 php:

--- a/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
@@ -13,7 +13,6 @@ master:
       cpu: "250m"
       memory: "1Gi"
     limits:
-      cpu: null
       memory: "1Gi"
   persistence:
     enabled: true
@@ -29,7 +28,6 @@ data:
       cpu: "500m"
       memory: "8Gi"
     limits:
-      cpu: null
       memory: "8Gi"
   persistence:
     enabled: true

--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -23,26 +23,22 @@ resources:
       cpu: 100m
       memory: 250Mi
     limits:
-      cpu: null
       memory: 750Mi
   webapi:
     requests:
       cpu: 100m
       memory: 125Mi
     limits:
-      cpu: null
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: null
       memory: 600Mi
   backend:
     requests:
       cpu: 125m
       memory: 200Mi
     limits:
-      cpu: null
       memory: 1200Mi

--- a/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
@@ -6,5 +6,4 @@ resources:
     cpu: 60m
     memory: 50Mi
   limits:
-    cpu: null
     memory: 100Mi

--- a/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
@@ -8,7 +8,6 @@ resources:
     cpu: 0.5
     memory: "2048Mi"
   limits:
-    cpu: null
     memory: "3072Mi"
 
 persistence:

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -4,7 +4,6 @@ primary:
       cpu: 750m
       memory: 1000Mi
     limits:
-      cpu: null
       memory: 1000Mi
   configuration: |-
     [mysqld]
@@ -61,7 +60,6 @@ secondary:
       cpu: 750m
       memory: 900Mi
     limits:
-      cpu: null
       memory: 900Mi
   readinessProbe:
     enabled: false


### PR DESCRIPTION
This commit removes cpu limites rather than setting them to null

I notive on a number of occasions this causes issues with the k8s api which treats null as 0 and then results in errors applying a request that is more than 0.

Instead this simply doesn't set any limit