### PR TITLE
helmfile: fixup for argocd-config 1.0.8

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -109,7 +109,7 @@ releases:
   - name: argocd-config
     namespace: argocd
     chart: wbstack/argocd-config
-    version: '{{ if eq .Environment.Name "production" }} 1.0.7 {{ else }} 1.0.8 {{ end }}'
+    version: '{{ if eq .Environment.Name "production" }} 1.0.7 {{ else }} 1.0.9 {{ end }}'
     <<: *default_release
 
   - name: redirects


### PR DESCRIPTION
Unfortunately 1.0.8 was mistakenly configured to use https://github.com/wbstack/charts.git rather than
https://wbstack.github.io/charts and therefore wasn't correctly parsing the chart without a path. 1.0.9 is a fixup for this that uses the correct repoURL

Bug: T375195