### PR TITLE
staging(argocd): increase memory request

### DIFF
--- a/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
@@ -5,6 +5,14 @@ dex:
     requests:
       memory: 64Mi
 
+controller:
+  resources:
+   limits:
+     memory: 512Mi
+   requests:
+     cpu: 250m
+     memory: 512Mi
+
 configs:
   cm:
     ui.bannercontent: "STAGING"


### PR DESCRIPTION
We seem to regularly be being OOM killed so this commit increases the request to match the limit of 512Mi

Bug: T375195

