### PR TITLE
redis: staging and production remove master cpu limit

### DIFF
--- a/k8s/argocd/production/redis.values.yaml
+++ b/k8s/argocd/production/redis.values.yaml
@@ -25,7 +25,6 @@ master:
     subPath: ""
   resources:
     limits:
-      cpu: 500m
       memory: 500Mi
     requests:
       cpu: 500m

--- a/k8s/argocd/staging/redis.values.yaml
+++ b/k8s/argocd/staging/redis.values.yaml
@@ -25,7 +25,6 @@ master:
     subPath: ""
   resources:
     limits:
-      cpu: 500m
       memory: 500Mi
     requests:
       cpu: 500m

--- a/k8s/helmfile/env/production/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/redis.values.yaml.gotmpl
@@ -25,7 +25,6 @@ master:
       memory: 500Mi
     # Internal limit is 75MB, this for now just stops runaway redis..
     limits:
-      cpu: 500m
       memory: 500Mi
 
 replica:


### PR DESCRIPTION
It appears that while the replica limit was removed in #1788 the master limit was overlooked. This also removes it here also

### Prior discussion
Discovered as an issue due in #1869

Bug: T380777