### PR TITLE
remove argo cpu limits

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -42,7 +42,6 @@ configs:
 controller:
   resources:
    limits:
-     cpu: null
      memory: 512Mi
    requests:
      cpu: 250m
@@ -51,7 +50,6 @@ controller:
 applicationSet:
   resources:
     limits:
-      cpu: null
       memory: 128Mi
     requests:
       cpu: 100m
@@ -60,7 +58,6 @@ applicationSet:
 dex:
   resources:
    limits:
-     cpu: null
      memory: 64Mi
    requests:
      cpu: 10m
@@ -69,7 +66,6 @@ dex:
 notifications:
   resources:
     limits:
-      cpu: null
       memory: 128Mi
     requests:
       cpu: 100m
@@ -78,7 +74,6 @@ notifications:
 redis:
   resources:
    limits:
-     cpu: null
      memory: 128Mi
    requests:
      cpu: 100m
@@ -87,7 +82,6 @@ redis:
 repoServer:
   resources:
    limits:
-     cpu: null
      memory: 1024Mi
    requests:
      cpu: 10m


### PR DESCRIPTION
There was some discussion recently about this, but I fail to remember the outcome why this was added and then reverted and such. All I know is that without this currently a local cluster re-initialization is not working, so we should change *something*. Change requests/feedback/etc welcome

