### PR TITLE
prod: bump argocd dex memory limit to match staging

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -58,10 +58,10 @@ applicationSet:
 dex:
   resources:
    limits:
-     memory: 64Mi
+     memory: 128Mi
    requests:
      cpu: 10m
-     memory: 32Mi
+     memory: 64Mi
 
 notifications:
   resources:

--- a/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
@@ -1,10 +1,3 @@
-dex:
-  resources:
-    limits:
-      memory: 128Mi
-    requests:
-      memory: 64Mi
-
 controller:
   resources:
    limits:


### PR DESCRIPTION
The argocd-dex-server is continually crashing and restarting with error 139 in production. There are a lot of logs coming from this pod that may be related to this.

Unfortunately it had less memory request and limit than staging

This patch hopes to resolve the crashing issue but also to correct the discrepancy that staging has more resources than production; this should probably never happen.

Bug: T380029