### PR TITLE
argo: disable dex in all environments

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -55,14 +55,6 @@ applicationSet:
       cpu: 100m
       memory: 128Mi
 
-dex:
-  resources:
-   limits:
-     memory: 64Mi
-   requests:
-     cpu: 10m
-     memory: 32Mi
-
 notifications:
   resources:
     limits:


### PR DESCRIPTION
this commit removes the resources setting that appears to be inadvertantly re-enabling the dex server and config after it was attempted to be disabled at the top of
production/argo-cd-base.values.yaml.gotmpl

Bug: T381960