### PR TITLE
use clusterissuer chart 0.2.0

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -79,7 +79,7 @@ releases:
   - name: clusterissuers
     namespace: cert-manager
     chart: wbstack/wikibase-cloud-clusterissuers
-    version: 0.1.0
+    version: 0.2.0
     values:
       - email: {{ .Values.external.letsencrypt.email }}
       - gceProject: {{ .Values.gceProject }}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T378691

follow up to https://github.com/wmde/wbaas-deploy/pull/1868

it was missing using the new chart
