### PR TITLE
local tls: add ca cert export and documentation + argo cert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+wikibase-local-ca.crt
+

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,8 @@ help:
 .PHONY: local-ca
 local-ca: # @HELP Get the CA certificate that is used in the local environment
 local-ca:
-	kubectl get secret wikibase-local-tls -o json | jq -r '.data."ca.crt"' | base64 -d > wikibase-local-tls.crt
-	realpath wikibase-local-tls.crt
+	kubectl get secret wikibase-local-tls -o json | jq -r '.data."ca.crt"' | base64 -d > wikibase-local-ca.crt
+	realpath wikibase-local-ca.crt
 
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ help:
 	        { printf "  %-20s %s\n", $$1, $$2 };  \
 	    '
 
+.PHONY: local-ca
+local-ca: # @HELP Get the CA certificate that is used in the local environment
+local-ca:
+	kubectl get secret wikibase-local-tls -o json | jq -r '.data."ca.crt"' | base64 -d > wikibase-local-tls.crt
+	realpath wikibase-local-tls.crt
+
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube
 minikube-start:

--- a/doc/local-dev-env.md
+++ b/doc/local-dev-env.md
@@ -245,6 +245,15 @@ sudo wget https://raw.githubusercontent.com/roboll/helmfile/master/autocomplete/
 sudo sh -c 'skaffold completion bash > /usr/share/bash-completion/completions/skaffold'
 ```
 
+## [Optional] install local CA certificate
+Since we [introduced](https://phabricator.wikimedia.org/T378691) using HTTPS for local ingresses, you will get a scary warning when accessing local web interfaces. This can be mitigated by trusting the local CA certificate that is getting used for self-signing. The easiest way to do this is to save the local CA certificate in a file by accessing the secret it lives in (`wikibase-local-tls`) and importing it in your browser. There is also the possibility to import it into the trust store of your operating system, for example via the tool [mkcert](https://github.com/FiloSottile/mkcert), but you should be aware of the possible consequences this could have for the security of your machine.
+
+> [!TIP]
+> Running `make local-ca` will save the certificate to the file `wikibase-local-tls.crt`. It is highly recommended to delete the file again after importing it.
+
+> [!NOTE]
+> If you recreate your local cluster, you have to re-import the CA certificate, as a new one will get generated and used instead.
+
 ## Testing changes
 [skaffold](https://skaffold.dev) is used to load changes made in other repositories (e.g. `api`, `mediawiki`, `quickstatements`, etc) into the pods running in minikube. See the [README](../skaffold/README.md) in the skaffold directory for details on how to use.
 
@@ -270,7 +279,7 @@ it is likely because `make diff-local` uses the `--skip-deps` option when execut
 Here are a few things to try:
   - make sure minikube is running `make minikube-start`
   - make sure the minikube tunnel is running `make minikube-tunnel`
-  - make sure you are using http:// and not https:// (there are no TLS certificates)
+  - make sure you are using https:// and not http://
   - check the health of your pods `kubectl --profile minikube-wbaas get pods`
 
 ### **API isn't running // Some pods are missing**

--- a/doc/local-dev-env.md
+++ b/doc/local-dev-env.md
@@ -246,7 +246,7 @@ sudo sh -c 'skaffold completion bash > /usr/share/bash-completion/completions/sk
 ```
 
 ## [Optional] install local CA certificate
-Since we [introduced](https://phabricator.wikimedia.org/T378691) using HTTPS for local ingresses, you will get a scary warning when accessing local web interfaces. This can be mitigated by trusting the local CA certificate that is getting used for self-signing. The easiest way to do this is to save the local CA certificate in a file by accessing the secret it lives in (`wikibase-local-tls`) and importing it in your browser. There is also the possibility to import it into the trust store of your operating system, for example via the tool [mkcert](https://github.com/FiloSottile/mkcert), but you should be aware of the possible consequences this could have for the security of your machine.
+Since we [introduced](https://phabricator.wikimedia.org/T378691) using HTTPS for local ingresses, you will get a scary warning when accessing local web interfaces. This can be mitigated by trusting the local CA certificate that is getting used for self-signing. The easiest way to do this is to save the local CA certificate in a file by accessing the secret it lives in (`wikibase-local-tls`) and importing it in your browser settings. There is also the possibility to import it into the trust store of your operating system, for example via the tool [mkcert](https://github.com/FiloSottile/mkcert), but you should be aware of the possible consequences this could have for the security of your machine.
 
 > [!TIP]
 > Running `make local-ca` will save the certificate to the file `wikibase-local-tls.crt`. It is highly recommended to delete the file again after importing it.

--- a/k8s/helmfile/env/local/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/argo-cd-base.values.yaml.gotmpl
@@ -27,7 +27,3 @@ server:
   ingress:
     enabled: true
     ingressClassName: nginx
-    annotations:
-      nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
-      nginx.ingress.kubernetes.io/ssl-passthrough: "false"
-    tls: false

--- a/k8s/helmfile/env/local/certificates.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/certificates.values.yaml.gotmpl
@@ -5,4 +5,4 @@ certificates:
       - '*.wbaas.localhost'
       - 'wbaas.localhost'
     secretName: wikibase-local-tls
-    issuerRef: selfsigned-cluster-issuer
+    issuerRef: wikibase-local-issuer

--- a/k8s/helmfile/env/local/certificates.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/certificates.values.yaml.gotmpl
@@ -6,3 +6,10 @@ certificates:
       - 'wbaas.localhost'
     secretName: wikibase-local-tls
     issuerRef: wikibase-local-issuer
+  - name: argocd-server-tls
+    namespace: argocd
+    commonName: argo.wbaas.localhost
+    dnsNames:
+      - 'argo.wbaas.localhost'
+    secretName: argocd-server-tls
+    issuerRef: wikibase-local-issuer

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -79,7 +79,7 @@ releases:
   - name: clusterissuers
     namespace: cert-manager
     chart: wbstack/wikibase-cloud-clusterissuers
-    version: 0.2.0
+    version: 0.2.1
     values:
       - email: {{ .Values.external.letsencrypt.email }}
       - gceProject: {{ .Values.gceProject }}

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -95,7 +95,7 @@ releases:
   - name: certificates
     namespace: default
     chart: wbstack/certificates
-    version: 0.1.0
+    version: 0.1.1
     <<: *default_release
 
   - name: argocd-config


### PR DESCRIPTION
https://phabricator.wikimedia.org/T378691

This adds a makefile target to easily export the local CA certiface that gets used to self-sign the locally used TLS certificates. This can get used to circumvent browser warnings.

- also adds config to issue local argo a certificate
