### PR TITLE
DNM: example conf for deploying querybuilder chart

### DIFF
--- a/k8s/helmfile/env/local/tool-querybuilder.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/tool-querybuilder.values.yaml.gotmpl
@@ -1,0 +1,10 @@
+resources: 
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+platform:
+  mediawikiBackendHost: mediawiki-139-app-backend.default.svc.cluster.local

--- a/k8s/helmfile/env/production/tool-querybuilder.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-querybuilder.values.yaml.gotmpl
@@ -1,0 +1,20 @@
+# Default values for tool-querybuilder.
+
+replicaCount: 1
+
+image:
+  tag: "2024-12-03-110242"
+
+platform:
+  mediawikiBackendHost: someHost
+
+app:
+  subclassPropertyMap: '{"default":"P279","P171":"P171","P131":"P131"}'
+  siConversionProperty: 'P2370'
+
+resources:
+  limits:
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -194,6 +194,11 @@ releases:
     version: 0.2.3
     <<: *default_release
 
+  - name: tool-querybuilder
+    namespace: default
+    chart: ../../../charts/charts/tool-querybuilder
+    <<: *default_release
+
   - name: wbaas-backup
     namespace: default
     chart: wbstack/wbaas-backup


### PR DESCRIPTION
https://phabricator.wikimedia.org/T381855

This PR features example files to test the new chart for the QueryBuilder tool https://github.com/wbstack/charts/pull/182

it's not intended to be merged right now but can be used as a reference in the future.

