### PR TITLE
skaffold: api to use kubectl post argocd

### DIFF
--- a/skaffold/k8s/api-app-backend.yaml
+++ b/skaffold/k8s/api-app-backend.yaml
@@ -1,0 +1,219 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: api
+    app.kubernetes.io/version: "1.0"
+    argocd.argoproj.io/instance: api
+    helm.sh/chart: api-0.35.0
+  name: api-app-backend
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app-backend
+      app.kubernetes.io/instance: api
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: app-backend
+        app.kubernetes.io/instance: api
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+      - env:
+        - name: CONTAINER_ROLE
+          value: app
+        - name: ROUTES_LOAD_WEB
+          value: "0"
+        - name: ROUTES_LOAD_BACKEND
+          value: "1"
+        - name: APP_NAME
+          value: WBaaS Localhost
+        - name: APP_ENV
+          value: local
+        - name: APP_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-app-key
+              name: api-app-secrets
+        - name: APP_DEBUG
+          value: "true"
+        - name: APP_URL
+          value: https://www.wbaas.dev
+        - name: APP_TIMEZONE
+          value: UTC
+        - name: WBSTACK_SUBDOMAIN_SUFFIX
+          value: .wbaas.dev
+        - name: WBSTACK_UI_URL
+          value: https://wbaas.dev
+        - name: WBSTACK_WIKI_DB_PROVISION_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_WIKI_DB_USE_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_SUMMARY_CREATION_RATE_RANGES
+          value: PT24H,P30D
+        - name: WBSTACK_SIGNUP_THROTTLING_LIMIT
+          value: "20"
+        - name: WBSTACK_SIGNUP_THROTTLING_RANGE
+          value: PT24H
+        - name: WBSTACK_QS_BATCH_PENDING_TIMEOUT
+          value: PT300S
+        - name: WBSTACK_QS_BATCH_MARK_FAILED_AFTER
+          value: "3"
+        - name: WBSTACK_CONTACT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_CONTACT_MAIL_SENDER
+          value: contact-<subject>@wbaas.dev
+        - name: WBSTACK_COMPLAINT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_COMPLAINT_MAIL_SENDER
+          value: dsa@wbaas.dev
+        - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
+          value: "true"
+        - name: TRUSTED_PROXY_PROXIES
+          value: '*'
+        - name: ELASTICSEARCH_SHARED_INDEX_HOST
+          value: elasticsearch-2.default.svc.cluster.local:9200
+        - name: ELASTICSEARCH_SHARED_INDEX_PREFIX
+          value: wiki_1
+        - name: QUERY_SERVICE_HOST
+          value: queryservice.default.svc.cluster.local:9999
+        - name: PLATFORM_MW_BACKEND_HOST
+          value: mediawiki-143-app-backend.default.svc.cluster.local
+        - name: REDIS_HOST
+          value: redis-master.default.svc.cluster.local
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: redis-password
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "2"
+        - name: REDIS_CACHE_DB
+          value: "3"
+        - name: REDIS_PREFIX
+          value: wikibase_dev_api
+        - name: MAIL_MAILER
+          value: smtp
+        - name: MAILGUN_DOMAIN
+          value: sandbox111.mailgun.org
+        - name: MAILGUN_SECRET
+          value: abc123
+        - name: MAIL_FROM_ADDRESS
+          value: noreply-local@fake.wikibase.dev
+        - name: MAIL_FROM_NAME
+          value: Wikibase-dev
+        - name: MAIL_HOST
+          value: mailhog
+        - name: MAIL_PORT
+          value: "1025"
+        - name: MAIL_ENCRYPTION
+          value: null
+        - name: MAIL_USERNAME
+        - name: MAIL_PASSWORD
+        - name: GOOGLE_CLOUD_PROJECT_ID
+          value: something
+        - name: GOOGLE_CLOUD_STORAGE_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              key: gcs_api_static_bucket_name
+              name: storage-bucket
+              optional: true
+        - name: GOOGLE_CLOUD_STORAGE_KEY_FILE
+          value: /var/run/secret/cloud.google.com/key.json
+        - name: LOG_CHANNEL
+          value: stderr
+        - name: LOG_LEVEL
+          value: debug
+        - name: STACKDRIVER_ENABLED
+          value: "false"
+        - name: STACKDRIVER_PROJECT_ID
+          value: something
+        - name: STACKDRIVER_LOGGING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_TRACING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_ERROR_REPORTING_ENABLED
+          value: "true"
+        - name: STACKDRIVER_KEY_FILE_PATH
+          value: /var/run/secret/cloud.google.com/key.json
+        - name: STACKDRIVER_ERROR_REPORTING_BATCH_ENABLED
+          value: "false"
+        - name: STACKDRIVER_LOGGING_BATCH_ENABLED
+          value: "false"
+        - name: CACHE_DRIVER
+          value: redis
+        - name: QUEUE_CONNECTION
+          value: redis
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: api-app-jwt-secret
+              name: api-app-secrets
+        - name: DB_CONNECTION
+          value: mysql
+        - name: DB_HOST_READ
+          value: sql-mariadb-secondary.default.svc.cluster.local
+        - name: DB_HOST_WRITE
+          value: sql-mariadb-primary.default.svc.cluster.local
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_DATABASE
+          value: apidb
+        - name: DB_USERNAME
+          value: apiuser
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SQL_INIT_PASSWORD_API
+              name: sql-secrets-init-passwords
+        - name: PASSPORT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-public.key
+              name: api-passport-keys
+        - name: PASSPORT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-private.key
+              name: api-passport-keys
+        image: ghcr.io/wbstack/api:10x.18.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /backend/healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: api-backend
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /backend/healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 1000m
+            memory: 600Mi
+          requests:
+            cpu: 200m
+            memory: 300Mi

--- a/skaffold/k8s/api-app-web.yaml
+++ b/skaffold/k8s/api-app-web.yaml
@@ -1,0 +1,244 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: api
+    app.kubernetes.io/version: "1.0"
+    argocd.argoproj.io/instance: api
+    helm.sh/chart: api-0.35.0
+  name: api-app-web
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: app-web
+      app.kubernetes.io/instance: api
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: app-web
+        app.kubernetes.io/instance: api
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+      - env:
+        - name: CONTAINER_ROLE
+          value: app
+        - name: ROUTES_LOAD_WEB
+          value: "1"
+        - name: ROUTES_LOAD_SANDBOX
+          value: "0"
+        - name: ROUTES_LOAD_BACKEND
+          value: "0"
+        - name: APP_NAME
+          value: WBaaS Localhost
+        - name: APP_ENV
+          value: local
+        - name: APP_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-app-key
+              name: api-app-secrets
+        - name: APP_DEBUG
+          value: "false"
+        - name: APP_URL
+          value: https://www.wbaas.dev
+        - name: APP_TIMEZONE
+          value: UTC
+        - name: WBSTACK_SUBDOMAIN_SUFFIX
+          value: .wbaas.dev
+        - name: WBSTACK_UI_URL
+          value: https://wbaas.dev
+        - name: WBSTACK_WIKI_DB_PROVISION_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_WIKI_DB_USE_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_SUMMARY_CREATION_RATE_RANGES
+          value: PT24H,P30D
+        - name: WBSTACK_SIGNUP_THROTTLING_LIMIT
+          value: "20"
+        - name: WBSTACK_SIGNUP_THROTTLING_RANGE
+          value: PT24H
+        - name: WBSTACK_QS_BATCH_PENDING_TIMEOUT
+          value: PT300S
+        - name: WBSTACK_QS_BATCH_MARK_FAILED_AFTER
+          value: "3"
+        - name: WBSTACK_CONTACT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_CONTACT_MAIL_SENDER
+          value: contact-<subject>@wbaas.dev
+        - name: WBSTACK_COMPLAINT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_COMPLAINT_MAIL_SENDER
+          value: dsa@wbaas.dev
+        - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
+          value: "true"
+        - name: TRUSTED_PROXY_PROXIES
+          value: '*'
+        - name: ELASTICSEARCH_SHARED_INDEX_HOST
+          value: elasticsearch-2.default.svc.cluster.local:9200
+        - name: ELASTICSEARCH_SHARED_INDEX_PREFIX
+          value: wiki_1
+        - name: QUERY_SERVICE_HOST
+          value: queryservice.default.svc.cluster.local:9999
+        - name: PLATFORM_MW_BACKEND_HOST
+          value: mediawiki-143-app-backend.default.svc.cluster.local
+        - name: REDIS_HOST
+          value: redis-master.default.svc.cluster.local
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: redis-password
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "2"
+        - name: REDIS_CACHE_DB
+          value: "3"
+        - name: REDIS_PREFIX
+          value: wikibase_dev_api
+        - name: MAIL_MAILER
+          value: smtp
+        - name: MAILGUN_DOMAIN
+          value: sandbox111.mailgun.org
+        - name: MAILGUN_SECRET
+          value: abc123
+        - name: MAIL_FROM_ADDRESS
+          value: noreply-local@fake.wikibase.dev
+        - name: MAIL_FROM_NAME
+          value: Wikibase-dev
+        - name: MAIL_HOST
+          value: mailhog
+        - name: MAIL_PORT
+          value: "1025"
+        - name: MAIL_ENCRYPTION
+          value: null
+        - name: MAIL_USERNAME
+        - name: MAIL_PASSWORD
+        - name: STATIC_STORAGE_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: gcs_api_static_bucket_name
+              name: storage-bucket
+              optional: true
+        - name: STATIC_STORAGE_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: rootUser
+              name: minio-credentials
+        - name: STATIC_STORAGE_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: rootPassword
+              name: minio-credentials
+        - name: STATIC_STORAGE_ENDPOINT
+          value: http://minio.default.svc.cluster.local:9000
+        - name: STATIC_STORAGE_URL
+          value: http://minio.wbaas.dev/api-assets
+        - name: STATIC_STORAGE_USE_BUCKET_ENDPOINT
+          value: "0"
+        - name: STATIC_STORAGE_USE_PATH_STYLE_ENDPOINT
+          value: "1"
+        - name: STATIC_STORAGE_REGION
+          value: us-east-1
+        - name: RECAPTCHA_V3_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: secret_key
+              name: recaptcha-v3-secrets
+        - name: RECAPTCHA_V3_MIN_SCORE
+          value: "0.5"
+        - name: LOG_CHANNEL
+          value: stderr
+        - name: LOG_LEVEL
+          value: debug
+        - name: STACKDRIVER_ENABLED
+          value: "false"
+        - name: STACKDRIVER_PROJECT_ID
+          value: something
+        - name: STACKDRIVER_LOGGING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_TRACING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_ERROR_REPORTING_ENABLED
+          value: "true"
+        - name: STACKDRIVER_KEY_FILE_PATH
+          value: /var/run/secret/cloud.google.com/key.json
+        - name: STACKDRIVER_ERROR_REPORTING_BATCH_ENABLED
+          value: "false"
+        - name: STACKDRIVER_LOGGING_BATCH_ENABLED
+          value: "false"
+        - name: CACHE_DRIVER
+          value: redis
+        - name: QUEUE_CONNECTION
+          value: redis
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: api-app-jwt-secret
+              name: api-app-secrets
+        - name: DB_CONNECTION
+          value: mysql
+        - name: DB_HOST_READ
+          value: sql-mariadb-secondary.default.svc.cluster.local
+        - name: DB_HOST_WRITE
+          value: sql-mariadb-primary.default.svc.cluster.local
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_DATABASE
+          value: apidb
+        - name: DB_USERNAME
+          value: apiuser
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SQL_INIT_PASSWORD_API
+              name: sql-secrets-init-passwords
+        - name: PASSPORT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-public.key
+              name: api-passport-keys
+        - name: PASSPORT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-private.key
+              name: api-passport-keys
+        image: ghcr.io/wbstack/api:10x.18.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        name: api-web
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 2
+        resources:
+          limits:
+            cpu: 250m
+            memory: 400Mi
+          requests:
+            cpu: 100m
+            memory: 340Mi

--- a/skaffold/k8s/api-queue-default.yaml
+++ b/skaffold/k8s/api-queue-default.yaml
@@ -1,0 +1,255 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: api
+    app.kubernetes.io/version: "1.0"
+    argocd.argoproj.io/instance: api
+    helm.sh/chart: api-0.35.0
+  name: api-queue-default
+  namespace: default
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: queue-default
+      app.kubernetes.io/instance: api
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: queue-default
+        app.kubernetes.io/instance: api
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+      - env:
+        - name: CONTAINER_ROLE
+          value: queue
+        - name: APP_NAME
+          value: WBaaS Localhost
+        - name: APP_ENV
+          value: local
+        - name: APP_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-app-key
+              name: api-app-secrets
+        - name: APP_DEBUG
+          value: "false"
+        - name: APP_URL
+          value: https://www.wbaas.dev
+        - name: APP_TIMEZONE
+          value: UTC
+        - name: WBSTACK_SUBDOMAIN_SUFFIX
+          value: .wbaas.dev
+        - name: WBSTACK_UI_URL
+          value: https://wbaas.dev
+        - name: WBSTACK_WIKI_DB_PROVISION_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_WIKI_DB_USE_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_SUMMARY_CREATION_RATE_RANGES
+          value: PT24H,P30D
+        - name: WBSTACK_SIGNUP_THROTTLING_LIMIT
+          value: "20"
+        - name: WBSTACK_SIGNUP_THROTTLING_RANGE
+          value: PT24H
+        - name: WBSTACK_QS_BATCH_PENDING_TIMEOUT
+          value: PT300S
+        - name: WBSTACK_QS_BATCH_MARK_FAILED_AFTER
+          value: "3"
+        - name: WBSTACK_CONTACT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_CONTACT_MAIL_SENDER
+          value: contact-<subject>@wbaas.dev
+        - name: WBSTACK_COMPLAINT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_COMPLAINT_MAIL_SENDER
+          value: dsa@wbaas.dev
+        - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
+          value: "true"
+        - name: TRUSTED_PROXY_PROXIES
+          value: '*'
+        - name: ELASTICSEARCH_SHARED_INDEX_HOST
+          value: elasticsearch-2.default.svc.cluster.local:9200
+        - name: ELASTICSEARCH_SHARED_INDEX_PREFIX
+          value: wiki_1
+        - name: CURLOPT_TIMEOUT_ELASTICSEARCH_INIT
+          value: "500"
+        - name: ELASTICSEARCH_HOST
+          value: elasticsearch-1.default.svc.cluster.local:9200
+        - name: QUERY_SERVICE_HOST
+          value: queryservice.default.svc.cluster.local:9999
+        - name: PLATFORM_MW_BACKEND_HOST
+          value: mediawiki-143-app-backend.default.svc.cluster.local
+        - name: REDIS_HOST
+          value: redis-master.default.svc.cluster.local
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: redis-password
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "2"
+        - name: REDIS_CACHE_DB
+          value: "3"
+        - name: REDIS_PREFIX
+          value: wikibase_dev_api
+        - name: MAIL_MAILER
+          value: smtp
+        - name: MAILGUN_DOMAIN
+          value: sandbox111.mailgun.org
+        - name: MAILGUN_SECRET
+          value: abc123
+        - name: MAIL_FROM_ADDRESS
+          value: noreply-local@fake.wikibase.dev
+        - name: MAIL_FROM_NAME
+          value: Wikibase-dev
+        - name: MAIL_HOST
+          value: mailhog
+        - name: MAIL_PORT
+          value: "1025"
+        - name: MAIL_ENCRYPTION
+          value: null
+        - name: MAIL_USERNAME
+        - name: MAIL_PASSWORD
+        - name: STATIC_STORAGE_BUCKET_NAME
+          valueFrom:
+            configMapKeyRef:
+              key: gcs_api_static_bucket_name
+              name: storage-bucket
+              optional: true
+        - name: STATIC_STORAGE_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: rootUser
+              name: minio-credentials
+        - name: STATIC_STORAGE_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              key: rootPassword
+              name: minio-credentials
+        - name: STATIC_STORAGE_ENDPOINT
+          value: http://minio.default.svc.cluster.local:9000
+        - name: STATIC_STORAGE_URL
+          value: http://minio.wbaas.dev/api-assets
+        - name: STATIC_STORAGE_USE_BUCKET_ENDPOINT
+          value: "0"
+        - name: STATIC_STORAGE_USE_PATH_STYLE_ENDPOINT
+          value: "1"
+        - name: STATIC_STORAGE_REGION
+          value: us-east-1
+        - name: LOG_CHANNEL
+          value: stderr
+        - name: LOG_LEVEL
+          value: debug
+        - name: STACKDRIVER_ENABLED
+          value: "false"
+        - name: STACKDRIVER_PROJECT_ID
+          value: something
+        - name: STACKDRIVER_LOGGING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_TRACING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_ERROR_REPORTING_ENABLED
+          value: "true"
+        - name: STACKDRIVER_KEY_FILE_PATH
+          value: /var/run/secret/cloud.google.com/key.json
+        - name: STACKDRIVER_ERROR_REPORTING_BATCH_ENABLED
+          value: "false"
+        - name: STACKDRIVER_LOGGING_BATCH_ENABLED
+          value: "false"
+        - name: CACHE_DRIVER
+          value: redis
+        - name: QUEUE_NAME
+          value: default
+        - name: QUEUE_CONNECTION
+          value: redis
+        - name: QUEUE_BACKOFF
+          value: 10,60,300,900,1500
+        - name: HORIZON_ENABLED
+          value: "1"
+        - name: HORIZON_QUEUE_NAMES
+          value: default,manual-intervention
+        - name: HORIZON_MAX_PROCESSES
+          value: "10"
+        - name: HORIZON_MIN_PROCESSES
+          value: "1"
+        - name: HORIZON_BALANCING_STRATEGY
+          value: auto
+        - name: HORIZON_AUTO_SCALING_STRATEGY
+          value: time
+        - name: HORIZON_MAX_SHIFT
+          value: "1"
+        - name: HORIZON_COOL_DOWN
+          value: "3"
+        - name: HORIZON_MEMORY
+          value: "128"
+        - name: HORIZON_TRIES
+          value: "3"
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: api-app-jwt-secret
+              name: api-app-secrets
+        - name: DB_CONNECTION
+          value: mysql
+        - name: DB_HOST_READ
+          value: sql-mariadb-secondary.default.svc.cluster.local
+        - name: DB_HOST_WRITE
+          value: sql-mariadb-primary.default.svc.cluster.local
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_DATABASE
+          value: apidb
+        - name: DB_USERNAME
+          value: apiuser
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SQL_INIT_PASSWORD_API
+              name: sql-secrets-init-passwords
+        - name: MW_DB_HOST_READ
+          value: sql-mariadb-secondary.default.svc.cluster.local
+        - name: MW_DB_HOST_WRITE
+          value: sql-mariadb-primary.default.svc.cluster.local
+        - name: MW_DB_USERNAME
+          value: mediawiki-db-manager
+        - name: MW_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SQL_INIT_PASSWORD_MW
+              name: sql-secrets-init-passwords
+        - name: PASSPORT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-public.key
+              name: api-passport-keys
+        - name: PASSPORT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-private.key
+              name: api-passport-keys
+        - name: API_JOB_NAMESPACE
+          value: api-jobs
+        image: ghcr.io/wbstack/api:10x.18.2
+        imagePullPolicy: IfNotPresent
+        name: api-queue-default
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 250m
+            memory: 512Mi
+          requests:
+            cpu: 100m
+            memory: 256Mi
+      serviceAccountName: api-defaultrole

--- a/skaffold/k8s/api-scheduler.yaml
+++ b/skaffold/k8s/api-scheduler.yaml
@@ -1,0 +1,197 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  labels:
+    app.kubernetes.io/instance: api
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: api
+    app.kubernetes.io/version: "1.0"
+    argocd.argoproj.io/instance: api
+    helm.sh/chart: api-0.35.0
+  name: api-scheduler
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: scheduler
+      app.kubernetes.io/instance: api
+      app.kubernetes.io/name: api
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: scheduler
+        app.kubernetes.io/instance: api
+        app.kubernetes.io/name: api
+    spec:
+      containers:
+      - env:
+        - name: CONTAINER_ROLE
+          value: scheduler
+        - name: APP_NAME
+          value: WBaaS Localhost
+        - name: APP_ENV
+          value: local
+        - name: APP_KEY
+          valueFrom:
+            secretKeyRef:
+              key: api-app-key
+              name: api-app-secrets
+        - name: APP_DEBUG
+          value: "false"
+        - name: APP_URL
+          value: https://www.wbaas.dev
+        - name: APP_TIMEZONE
+          value: UTC
+        - name: WBSTACK_SUBDOMAIN_SUFFIX
+          value: .wbaas.dev
+        - name: WBSTACK_UI_URL
+          value: https://wbaas.dev
+        - name: WBSTACK_WIKI_DB_PROVISION_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_WIKI_DB_USE_VERSION
+          value: mw1.43-wbs1
+        - name: WBSTACK_SUMMARY_CREATION_RATE_RANGES
+          value: PT24H,P30D
+        - name: WBSTACK_SIGNUP_THROTTLING_LIMIT
+          value: "20"
+        - name: WBSTACK_SIGNUP_THROTTLING_RANGE
+          value: PT24H
+        - name: WBSTACK_QS_BATCH_PENDING_TIMEOUT
+          value: PT300S
+        - name: WBSTACK_QS_BATCH_MARK_FAILED_AFTER
+          value: "3"
+        - name: WBSTACK_CONTACT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_CONTACT_MAIL_SENDER
+          value: contact-<subject>@wbaas.dev
+        - name: WBSTACK_COMPLAINT_MAIL_RECIPIENT
+          value: someone@wikimedia.de
+        - name: WBSTACK_COMPLAINT_MAIL_SENDER
+          value: dsa@wbaas.dev
+        - name: WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT
+          value: "true"
+        - name: TRUSTED_PROXY_PROXIES
+          value: '*'
+        - name: ELASTICSEARCH_SHARED_INDEX_HOST
+          value: elasticsearch-2.default.svc.cluster.local:9200
+        - name: ELASTICSEARCH_SHARED_INDEX_PREFIX
+          value: wiki_1
+        - name: QUERY_SERVICE_HOST
+          value: queryservice.default.svc.cluster.local:9999
+        - name: PLATFORM_MW_BACKEND_HOST
+          value: mediawiki-143-app-backend.default.svc.cluster.local
+        - name: REDIS_HOST
+          value: redis-master.default.svc.cluster.local
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: password
+              name: redis-password
+        - name: REDIS_PORT
+          value: "6379"
+        - name: REDIS_DB
+          value: "2"
+        - name: REDIS_CACHE_DB
+          value: "3"
+        - name: REDIS_PREFIX
+          value: wikibase_dev_api
+        - name: MAIL_MAILER
+          value: smtp
+        - name: MAILGUN_DOMAIN
+          value: sandbox111.mailgun.org
+        - name: MAILGUN_SECRET
+          value: abc123
+        - name: MAIL_FROM_ADDRESS
+          value: noreply-local@fake.wikibase.dev
+        - name: MAIL_FROM_NAME
+          value: Wikibase-dev
+        - name: MAIL_HOST
+          value: mailhog
+        - name: MAIL_PORT
+          value: "1025"
+        - name: MAIL_ENCRYPTION
+          value: null
+        - name: MAIL_USERNAME
+        - name: MAIL_PASSWORD
+        - name: GOOGLE_CLOUD_PROJECT_ID
+          value: something
+        - name: GOOGLE_CLOUD_STORAGE_BUCKET
+          valueFrom:
+            configMapKeyRef:
+              key: gcs_api_static_bucket_name
+              name: storage-bucket
+              optional: true
+        - name: GOOGLE_CLOUD_STORAGE_KEY_FILE
+          value: /var/run/secret/cloud.google.com/key.json
+        - name: LOG_CHANNEL
+          value: stderr
+        - name: LOG_LEVEL
+          value: debug
+        - name: STACKDRIVER_ENABLED
+          value: "false"
+        - name: STACKDRIVER_PROJECT_ID
+          value: something
+        - name: STACKDRIVER_LOGGING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_TRACING_ENABLED
+          value: "false"
+        - name: STACKDRIVER_ERROR_REPORTING_ENABLED
+          value: "true"
+        - name: STACKDRIVER_KEY_FILE_PATH
+          value: /var/run/secret/cloud.google.com/key.json
+        - name: STACKDRIVER_ERROR_REPORTING_BATCH_ENABLED
+          value: "false"
+        - name: STACKDRIVER_LOGGING_BATCH_ENABLED
+          value: "false"
+        - name: CACHE_DRIVER
+          value: redis
+        - name: QUEUE_CONNECTION
+          value: redis
+        - name: JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              key: api-app-jwt-secret
+              name: api-app-secrets
+        - name: DB_CONNECTION
+          value: mysql
+        - name: DB_HOST_READ
+          value: sql-mariadb-secondary.default.svc.cluster.local
+        - name: DB_HOST_WRITE
+          value: sql-mariadb-primary.default.svc.cluster.local
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_DATABASE
+          value: apidb
+        - name: DB_USERNAME
+          value: apiuser
+        - name: DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: SQL_INIT_PASSWORD_API
+              name: sql-secrets-init-passwords
+        - name: PASSPORT_PUBLIC_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-public.key
+              name: api-passport-keys
+        - name: PASSPORT_PRIVATE_KEY
+          valueFrom:
+            secretKeyRef:
+              key: oauth-private.key
+              name: api-passport-keys
+        image: ghcr.io/wbstack/api:10x.18.2
+        imagePullPolicy: IfNotPresent
+        name: api-queue
+        ports:
+        - containerPort: 80
+          name: http
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 40m
+            memory: 80Mi
+          requests:
+            cpu: 5m
+            memory: 20Mi

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -120,27 +120,13 @@ profiles:
       - kubeContext: minikube-wbaas
     build:
       artifacts:
-        - image: local/skaffold/wbaas/api
+        - image: ghcr.io/wbstack/api
           context: ./../../api
       local:
         useDockerCLI: true
     deploy:
       kubeContext: minikube-wbaas
-      helm:
-        releases:
-          - name: api
-            chartPath: ./../../charts/charts/api
-            valuesFiles:
-              - ".tmp.values.api.yaml"
-              - NeverPull.yaml
-            artifactOverrides:
-              image: local/skaffold/wbaas/api
-            imageStrategy:
-              helm: {}
-        hooks:
-          before:
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "api", "-n" ]
+      kubectl: {}
 metadata:
   name: api
 


### PR DESCRIPTION
## Describe the changes
This stops using helm and uses plain kubectl to deploy the changes since after argo there is now no helm owned releases in the local cluster
<!--
	To help reviewers with understanding the changes at hand, provide a
	short summary of:
		1. why is this change needed?
		2. what led to choosing the current implementation?
		3. are there any alternative solutions you considered, but did not
           pursue further?
-->

## This is what I need help with

<!--
	Help the reviewer understand what you are looking for in the review. Are
	there certain parts of the code you are unsure about? Is there anything that
	should **not** be reviewed yet? To which extent did you already perform QA
	on this change?
-->

## Link to Phabricator

<!--
	Provide a link to the relevant Phabricator ticket for this Pull Request.
	If there is none, try to explain what prompted opening this PR (e.g. adhoc
	resolution of an incident, typo fix or similar).
-->

### Prior discussion
You can cherry-pick this branch on to the latest main to see if this workaround will allow you to successfully skaffold the api.