### PR TITLE
tf(prod): clarify production-site-request-count

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -13,9 +13,7 @@ resource "google_logging_metric" "production-site-request-count" {
   filter      = <<-EOT
         labels."k8s-pod/app_kubernetes_io/name"="ingress-nginx"
         resource.type="k8s_container"
-        -textPayload:"GoogleStackdriverMonitoring"
-        -textPayload:"cert-manager"
-        -textPayload:"Widar"
+        textPayload=~"^\d*\.\d*\.\d*\.\d*\ - (-|\w) \["
     EOT
   label_extractors = {
     "domain"     = "REGEXP_EXTRACT(textPayload, \"\\\\w+ https:\\\\/\\\\/([^\\\\/]+)\")"


### PR DESCRIPTION
This commit tweaks the log based metric to more specifically target just incoming requests rather than also error log lines etc. from nginx

This uses a regex that should match an ipv4, a dash, the possible
- or $remote_user and the [ at the start of the timestamp.

Bug: T385969