### PR TITLE
prod(tf): fix permenant dashboard diff

### DIFF
--- a/doc/managing-google-cloud-resources.md
+++ b/doc/managing-google-cloud-resources.md
@@ -1,0 +1,10 @@
+# Managing google cloud resources
+
+They are managed using opentofu.
+
+It may be necessary to generate the configuration for them and import them as shown in [importing-resources-into-opentofu.md].
+
+It may also be necessary for very complex JSON objects to store as a simple `.json` fild rather than inline in the `.tf`.
+
+The format of these objects; and partocularly how they handle defaults can drift overtime.
+In this case to prevent perpetual diffs it may be necessary to update the json but downloading it from the google api. e.g. https://cloud.google.com/monitoring/api/ref_v3/rest/v1/projects.dashboards/get for dashboards.

--- a/tf/env/production/es-prometheus-dashboard-json.json
+++ b/tf/env/production/es-prometheus-dashboard-json.json
@@ -1,5 +1,7 @@
 {
+  "name": "projects/658442145969/dashboards/e771ea98-5c12-4b10-9c85-47d4abceaec7",
   "displayName": "Elasticsearch Prometheus Overview – Cluster filtering hardcoded",
+  "etag": "5ce2ea3f4c83058d1e8042e7d4c617bf",
   "mosaicLayout": {
     "columns": 12,
     "tiles": [
@@ -14,8 +16,7 @@
               {
                 "timeSeriesQuery": {
                   "prometheusQuery": "elasticsearch_cluster_health_status{${Cluster},${Location},${Namespace}}"
-                },
-                "minAlignmentPeriod": "0s"
+                }
               }
             ],
             "metricVisualization": "NUMBER"
@@ -156,8 +157,7 @@
               {
                 "timeSeriesQuery": {
                   "prometheusQuery": "elasticsearch_process_open_files_count{${Cluster},${Location},${Namespace}}"
-                },
-                "minAlignmentPeriod": "0s"
+                }
               }
             ],
             "metricVisualization": "NUMBER"
@@ -327,17 +327,20 @@
       "labelKey": "cluster",
       "templateVariable": "Cluster",
       "stringValue": "wbaas-3",
-      "filterType": "RESOURCE_LABEL"
+      "filterType": "RESOURCE_LABEL",
+      "valueType": "STRING"
     },
     {
       "labelKey": "location",
       "templateVariable": "Location",
-      "filterType": "RESOURCE_LABEL"
+      "filterType": "RESOURCE_LABEL",
+      "valueType": "STRING"
     },
     {
       "labelKey": "namespace",
       "templateVariable": "Namespace",
-      "filterType": "RESOURCE_LABEL"
+      "filterType": "RESOURCE_LABEL",
+      "valueType": "STRING"
     }
   ]
 }


### PR DESCRIPTION
Like in #1635 the JSON format of the dashboards seems to have drifted.

I repeated the process used there to download the latest json using the api explorer.

I also added a short doc about this

Bug: T386614