### PR TITLE
prod(tofu): refine production-site-request-count

### DIFF
--- a/tf/env/production/monitoring.tf
+++ b/tf/env/production/monitoring.tf
@@ -14,11 +14,12 @@ resource "google_logging_metric" "production-site-request-count" {
         labels."k8s-pod/app_kubernetes_io/name"="ingress-nginx"
         resource.type="k8s_container"
         textPayload=~"^\d*\.\d*\.\d*\.\d*\ - (-|\w) \["
+        resource.labels.cluster_name="wbaas-3"
     EOT
   label_extractors = {
-    "domain"     = "REGEXP_EXTRACT(textPayload, \"\\\\w+ https:\\\\/\\\\/([^\\\\/]+)\")"
-    "httpMethod" = "REGEXP_EXTRACT(textPayload, \"(\\\\w+) https:\\\\/\\\\/[^ ]+ [^ ]+ \\\\d+\")"
-    "statuscode" = "REGEXP_EXTRACT(textPayload, \"\\\\w+ https:\\\\/\\\\/[^ ]+ [^ ]+ (\\\\d+)\")"
+    "domain"     = "REGEXP_EXTRACT(textPayload, \"^(?:[0-9\\\\.]+) - - \\\\[[^\\\\]]+\\\\] \\\\\\\"(?:GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH) https?:\\\\/\\\\/([^\\\\/\\\\s]+)[^\\\\\\\"]*\\\\\\\" \\\\d{3}\")"
+    "httpMethod" = "REGEXP_EXTRACT(textPayload, \"^(?:[0-9\\\\.]+) - - \\\\[[^\\\\]]+\\\\] \\\\\\\"(GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH) https?:\\\\/\\\\/[^\\\\/\\\\s]+[^\\\\\\\"]*\\\\\\\" \\\\d{3}\")"
+    "statuscode" = "REGEXP_EXTRACT(textPayload, \"^(?:[0-9\\\\.]+) - - \\\\[[^\\\\]]+\\\\] \\\\\\\"(?:GET|POST|PUT|DELETE|HEAD|OPTIONS|PATCH) https?:\\\\/\\\\/[^\\\\/\\\\s]+[^\\\\\\\"]*\\\\\\\" (\\\\d{3})\")"
   }
   name    = "production-site-request-count"
   project = "wikibase-cloud"


### PR DESCRIPTION
This copies the staging log based metric

This commit even further refines the log based metric. Specifically it now isolates the it to only contain wbaas-3 metrics.

Secondly it tightens the label extraction. This is specifically to target the edge case of things like urls included in user agent strings

Bug: T385969
