### PR TITLE
use wikibase-cloud-clusterissuers v0.3.0

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -79,7 +79,7 @@ releases:
   - name: clusterissuers
     namespace: cert-manager
     chart: wbstack/wikibase-cloud-clusterissuers
-    version: 0.2.1
+    version: 0.3.0
     values:
       - environment: {{ .Environment.Name }}
       - email: {{ .Values.external.letsencrypt.email }}

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -81,6 +81,7 @@ releases:
     chart: wbstack/wikibase-cloud-clusterissuers
     version: 0.2.1
     values:
+      - environment: {{ .Environment.Name }}
       - email: {{ .Values.external.letsencrypt.email }}
       - gceProject: {{ .Values.gceProject }}
       # TODO this chart needs certificates for some reason, it probably shouldn't


### PR DESCRIPTION
https://phabricator.wikimedia.org/T383335#10591561

uses https://github.com/wbstack/charts/pull/187 in order to deploy only the clusterissuer needed for the current environment

