### PR TITLE
use nginx-ingress chart v4.12.1

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -114,7 +114,7 @@ releases:
   - name: ingress-nginx
     namespace: kube-system
     chart: ingress-nginx/ingress-nginx
-    version: 4.10.1
+    version: 4.12.1
     # TODO: future releases of `helmfile` will bring an `inherit` feature
     # that can be used instead of YAML anchors. When upgrading helmfile, check
     # if we can use this feature here instead.


### PR DESCRIPTION
security fix, see https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/

