### PR TITLE
prod(tf): reduce elasticsearch-master cpu request

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
@@ -16,7 +16,7 @@ master:
   heapSize: 4000m
   resources:
     requests:
-      cpu: "2000m"
+      cpu: "300m"
       memory: "8Gi"
     limits:
       cpu: null


### PR DESCRIPTION
Looking at the last 12 weeks we didn't use more than 200m cpu for elasticsearch master. Let's massively reduce the request to 300m.

Written with @AndrewKostka at KubeCon2025

Bug: T390698
