### PR TITLE
prod(tf): reduce elasticsearch-data cpu request

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
@@ -40,7 +40,7 @@ data:
   heapSize: 8000m
   resources:
     requests:
-      cpu: "2000m"
+      cpu: "300m"
       memory: "18Gi"
     limits:
       cpu: null


### PR DESCRIPTION
Looking at the last 12 weeks we didn't use more than 140m cpu for elasticsearch master. Let's massively reduce the request to 300m.

Bug: T390698
