### PR TITLE
downgrade nginx-ingress to 4.11.5

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -114,7 +114,7 @@ releases:
   - name: ingress-nginx
     namespace: kube-system
     chart: ingress-nginx/ingress-nginx
-    version: 4.12.1
+    version: 4.11.5
     # TODO: future releases of `helmfile` will bring an `inherit` feature
     # that can be used instead of YAML anchors. When upgrading helmfile, check
     # if we can use this feature here instead.


### PR DESCRIPTION
https://phabricator.wikimedia.org/T390823

4.12.1 turned out to be incompatible with our api ingress path configs

```
Failed sync attempt to : one or more synchronization tasks completed unsuccessfully, reason: admission webhook "validate.nginx.ingress.kubernetes.io" denied the request: ingress contains invalid paths: path /()(.*) cannot be used with pathType Prefix path /api(/|$)(.*) cannot be used with pathType Prefix (retried 5 times).
```

4.11.5 still contains the security fixes and seems to work with the config

