### PR TITLE
use ingress-nginx 4.12.1 with less strict config

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -19,6 +19,7 @@ controller:
     limit-conn-status-code: 429
     custom-http-errors: "502,503"
     preserve-trailing-slash: true
+    strict-validate-path-type: false
     block-user-agents: ~*Seekport\sCrawler.*,~*MJ12bot.*,~Bytespider,~thesis-research-bot
     # https://stackoverflow.com/a/37877244
     log-format-upstream: >-

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -114,7 +114,7 @@ releases:
   - name: ingress-nginx
     namespace: kube-system
     chart: ingress-nginx/ingress-nginx
-    version: 4.11.5
+    version: 4.12.1
     # TODO: future releases of `helmfile` will bring an `inherit` feature
     # that can be used instead of YAML anchors. When upgrading helmfile, check
     # if we can use this feature here instead.


### PR DESCRIPTION
use the newer ingress-nginx chart again (compare https://github.com/wmde/wbaas-deploy/pull/2044)

and disable strict path types to keep api and ui ingress path config working

