### PR TITLE
increase staging sql disks (slightly)

### DIFF
--- a/k8s/helmfile/env/staging/private.yaml
+++ b/k8s/helmfile/env/staging/private.yaml
@@ -19,7 +19,7 @@ services:
           - /api(/|$)(.*)
   sql:
     storageClass: premium-rwo
-    storageSize: 61Gi
+    storageSize: 65Gi
     api:
       db: apidb
       user: apiuser


### PR DESCRIPTION
As I was writing some documentation on increasing sql disk storage, I tried this on staging - turns out you can't decrease anymore, so here's the update to keep our conf in sync.

> [!IMPORTANT]
> Before applying this, deleting the StatefulSets is necessary ([docs](https://github.com/wmde/wbaas-deploy/blob/3f0e015dbc5028baecfc4d34726c969cc9ae83d5/doc/increasing-sql-storage.md))
>   - `kubectl delete statefulset sql-mariadb-primary --cascade=orphan`
>  - `kubectl delete statefulset sql-mariadb-secondary --cascade=orphan`