### PR TITLE
sql statefulsets: remove cpu limits

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -10,7 +10,6 @@ primary:
       cpu: '2'
       memory: 8Gi
     limits:
-      cpu: null
       memory: 8Gi
   persistence:
     enabled: true
@@ -74,7 +73,6 @@ secondary:
       cpu: '2'
       memory: 8Gi
     limits:
-      cpu: null
       memory: 8Gi
   readinessProbe:
     enabled: true

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -4,7 +4,6 @@ primary:
       cpu: 750m
       memory: 1000Mi
     limits:
-      cpu: null
       memory: 1000Mi
   configuration: |-
     [mysqld]
@@ -61,7 +60,6 @@ secondary:
       cpu: 750m
       memory: 900Mi
     limits:
-      cpu: null
       memory: 900Mi
   readinessProbe:
     enabled: false


### PR DESCRIPTION
related: https://phabricator.wikimedia.org/T390823

Currently SQL StatefulSets can not come back up due to invalid cpu limits

```
  Warning  FailedCreate  2m6s (x30 over 3h27m)  statefulset-controller  create Pod sql-mariadb-primary-0 in StatefulSet sql-mariadb-primary failed error: Pod "sql-mariadb-primary-0"
 is invalid: spec.containers[0].resources.requests: Invalid value: "750m": must be less than or equal to cpu limit of 0
```
