### PR TITLE
prod(k8s): reduce api-backend cpu request

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -106,7 +106,7 @@ resources:
       cpu: 1000m
       memory: 600Mi
     requests:
-      cpu: 500m
+      cpu: 200m
       memory: 300Mi
   queue:
     limits:

--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -106,7 +106,7 @@ resources:
     limits:
       memory: 600Mi
     requests:
-      cpu: 500m
+      cpu: 200m
       memory: 300Mi
   queue:
     limits:

--- a/k8s/argocd/staging/api.values.yaml
+++ b/k8s/argocd/staging/api.values.yaml
@@ -107,7 +107,7 @@ resources:
     limits:
       memory: 600Mi
     requests:
-      cpu: 500m
+      cpu: 200m
       memory: 300Mi
   queue:
     limits:

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -144,7 +144,7 @@ resources:
   # The backed is a platform critical element, so make sure it is allowed to be a bit silly...
   backend:
     requests:
-      cpu: 500m
+      cpu: 200m
       memory: 300Mi
     limits:
       memory: 600Mi


### PR DESCRIPTION
Looking at the last 90 days weeks we used a rough, eyeballed average of 250m cpu.

This proposes setting the request to 80% of that

Bug: T390698
