### PR TITLE
prod(k8s): reduce api-queue cpu request

### DIFF
--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -112,7 +112,7 @@ resources:
     limits:
       memory: 1024Mi
     requests:
-      cpu: 500m
+      cpu: 1m
       memory: 512Mi
   scheduler:
     limits:

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -156,7 +156,7 @@ resources:
       memory: 400Mi
   queue:
     requests:
-      cpu: 500m
+      cpu: 1m
       memory: 512Mi
     limits:
       memory: 1024Mi


### PR DESCRIPTION
Looking at the last 90 days we used less than 1m cpu

This drops to reflect that

Bug: T390698
