### PR TITLE
prod(k8s): reduce sql-secondary cpu request

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -71,7 +71,7 @@ secondary:
       tailscale.com/expose: "true"
   resources:
     requests:
-      cpu: '2'
+      cpu: 400m
       memory: 8Gi
     limits:
       cpu: null


### PR DESCRIPTION
Looking at the last 90 days we used an average of 380m.

This proposes setting the request to just above that given how highly we value responsive sql

Bug: T390698
