### PR TITLE
prod(k8s): reduce sql-primary cpu request

### DIFF
--- a/k8s/helmfile/env/production/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/sql.values.yaml.gotmpl
@@ -7,7 +7,7 @@ auth:
 primary:
   resources:
     requests:
-      cpu: '2'
+      cpu: 100m
       memory: 8Gi
     limits:
       cpu: null


### PR DESCRIPTION
Looking at the last 90 days we used an average of 90m.

This proposes setting the request to just above that given how highly we value responsive sql

Bug: T390698