### PR TITLE
remove cpu limits follow up 

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
@@ -19,7 +19,6 @@ master:
       cpu: "300m"
       memory: "8Gi"
     limits:
-      cpu: null
       memory: "8Gi"
   persistence:
     enabled: true
@@ -43,7 +42,6 @@ data:
       cpu: "300m"
       memory: "18Gi"
     limits:
-      cpu: null
       memory: "18Gi"
   persistence:
     enabled: true

--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -7,8 +7,6 @@ controller:
     requests:
       cpu: 0.100
       memory: 150Mi
-    limits:
-      cpu: null
   config:
     http-snippet: >-
       limit_req_zone $host zone=limit_host:10m rate=15r/s;

--- a/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/mediawiki-139.values.yaml.gotmpl
@@ -61,26 +61,22 @@ resources:
       cpu: 500m
       memory: 1600Mi
     limits:
-      cpu: null
       memory: 2800Mi
   webapi:
     requests:
       cpu: 200m
       memory: 250Mi
     limits:
-      cpu: null
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: null
       memory: 600Mi
   backend:
     requests:
       cpu: 500m
       memory: 600Mi
     limits:
-      cpu: null
       memory: 1200Mi

--- a/k8s/helmfile/env/production/platform-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/platform-nginx.values.yaml.gotmpl
@@ -2,7 +2,6 @@ replicaCount: 3
 
 resources:
   limits:
-    cpu: null
     memory: 128Mi
   requests:
      cpu: 20m

--- a/k8s/helmfile/env/production/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-gateway.values.yaml.gotmpl
@@ -11,5 +11,4 @@ resources:
     cpu: 125m
     memory: 128Mi
   limits:
-    cpu: null
     memory: 256Mi

--- a/k8s/helmfile/env/production/queryservice-ui.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-ui.values.yaml.gotmpl
@@ -8,5 +8,4 @@ resources:
     cpu: 1m
     memory: 10Mi
   limits:
-    cpu: null
     memory: 25Mi

--- a/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice-updater.values.yaml.gotmpl
@@ -19,5 +19,4 @@ resources:
     cpu: 80m
     memory: 256Mi
   limits:
-    cpu: null
     memory: 512Mi

--- a/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
@@ -11,7 +11,6 @@ resources:
     cpu: 0.5
     memory: "3048Mi"
   limits:
-    cpu: null
     memory: "4072Mi"
 
 persistence:

--- a/k8s/helmfile/env/production/superset.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/superset.values.yaml.gotmpl
@@ -9,5 +9,4 @@ resources:
     cpu: 500m
     memory: 8Gi
   limits:
-    cpu: null
     memory: 8Gi

--- a/k8s/helmfile/env/production/tool-cradle.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-cradle.values.yaml.gotmpl
@@ -8,7 +8,6 @@ resources:
     cpu: 1m
     memory: 20Mi
   limits:
-    cpu: null
     memory: 60Mi
 
 replicaCount: 1

--- a/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
@@ -21,5 +21,4 @@ resources:
     cpu: 1m
     memory: 40Mi
   limits:
-    cpu: null
     memory: 100Mi

--- a/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-widar.values.yaml.gotmpl
@@ -11,7 +11,6 @@ resources:
     cpu: 1m
     memory: 18Mi
   limits:
-    cpu: null
     memory: 50Mi
 
 php:

--- a/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
@@ -13,7 +13,6 @@ master:
       cpu: "250m"
       memory: "1Gi"
     limits:
-      cpu: null
       memory: "1Gi"
   persistence:
     enabled: true
@@ -29,7 +28,6 @@ data:
       cpu: "500m"
       memory: "8Gi"
     limits:
-      cpu: null
       memory: "8Gi"
   persistence:
     enabled: true

--- a/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/mediawiki-139.values.yaml.gotmpl
@@ -23,26 +23,22 @@ resources:
       cpu: 100m
       memory: 250Mi
     limits:
-      cpu: null
       memory: 750Mi
   webapi:
     requests:
       cpu: 100m
       memory: 125Mi
     limits:
-      cpu: null
       memory: 1200Mi
   alpha:
     requests:
       cpu: 50m
       memory: 40Mi
     limits:
-      cpu: null
       memory: 600Mi
   backend:
     requests:
       cpu: 125m
       memory: 200Mi
     limits:
-      cpu: null
       memory: 1200Mi

--- a/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice-gateway.values.yaml.gotmpl
@@ -6,5 +6,4 @@ resources:
     cpu: 60m
     memory: 50Mi
   limits:
-    cpu: null
     memory: 100Mi

--- a/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
@@ -8,7 +8,6 @@ resources:
     cpu: 0.5
     memory: "2048Mi"
   limits:
-    cpu: null
     memory: "3072Mi"
 
 persistence:

--- a/k8s/helmfile/env/staging/superset.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/superset.values.yaml.gotmpl
@@ -3,5 +3,4 @@ resources:
     cpu: 100m
     memory: 750Mi
   limits:
-    cpu: 250m
     memory: 750Mi


### PR DESCRIPTION
follow up to https://github.com/wmde/wbaas-deploy/pull/2050

These are helmfile values only, so should be valid and mostly no-op (apart from staging superset because that value was not `null`). As far as I can see there is one limit left for the argo deployed redis but maybe we should touch that outside of this PR, as I'm currently not sure what brought us this ping-ponging back and forth between removing them and reverting again.

