### PR TITLE
staging: reduce ES requests

### DIFF
--- a/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
@@ -10,10 +10,9 @@ master:
   heapSize: 512m
   resources:
     requests:
-      cpu: "250m"
+      cpu: "100m"
       memory: "1Gi"
     limits:
-      cpu: null
       memory: "1Gi"
   persistence:
     enabled: true
@@ -26,10 +25,9 @@ data:
   heapSize: 4096m
   resources:
     requests:
-      cpu: "500m"
+      cpu: "250m"
       memory: "8Gi"
     limits:
-      cpu: null
       memory: "8Gi"
   persistence:
     enabled: true

--- a/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/elasticsearch-2.values.yaml.gotmpl
@@ -26,7 +26,7 @@ data:
   resources:
     requests:
       cpu: "250m"
-      memory: "8Gi"
+      memory: "7Gi"
     limits:
       memory: "8Gi"
   persistence:


### PR DESCRIPTION
Since we experience some struggles with resource allocation on staging[1], I looked into workloads where we could reduce requests. ES nodes seems like good candiates. This also removes the cpu limit setting that is probably misconfigured

[1] currently sql replica is struggling to allocate enough cpu: `Warning  FailedScheduling   2m7s (x237 over 19h)   default-scheduler   0/3 nodes are available: 1 Insufficient cpu, 2 Insufficient memory. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.`

![Screenshot from 2025-04-10 12-33-41](https://github.com/user-attachments/assets/36a85136-1d21-43d3-a449-1df0ffd19dac)

![image](https://github.com/user-attachments/assets/1a4cda10-3e26-4125-b9f1-b4e96c88028b)

