### PR TITLE
staging(tf): bump google tf provider to 6.29.0

### DIFF
--- a/tf/env/staging/providers.tf
+++ b/tf/env/staging/providers.tf
@@ -16,7 +16,7 @@ terraform {
     }
     google = {
       source  = "hashicorp/google"
-      version = "6.17.0"
+      version = "6.29.0"
     }
   }
 }


### PR DESCRIPTION
Regular update: perhaps to resolve issue seen in #2064 

Bug: T391569
