### PR TITLE
staging: reduce sql cpu requests

### DIFF
--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -1,7 +1,7 @@
 primary:
   resources:
     requests:
-      cpu: 750m
+      cpu: 350m
       memory: 1000Mi
     limits:
       memory: 1000Mi
@@ -57,7 +57,7 @@ secondary:
   replicaCount: 1
   resources:
     requests:
-      cpu: 750m
+      cpu: 350m
       memory: 900Mi
     limits:
       memory: 900Mi

--- a/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/sql.values.yaml.gotmpl
@@ -1,7 +1,7 @@
 primary:
   resources:
     requests:
-      cpu: 350m
+      cpu: 10m
       memory: 1000Mi
     limits:
       memory: 1000Mi
@@ -57,7 +57,7 @@ secondary:
   replicaCount: 1
   resources:
     requests:
-      cpu: 350m
+      cpu: 10m
       memory: 900Mi
     limits:
       memory: 900Mi


### PR DESCRIPTION
follow up to https://github.com/wmde/wbaas-deploy/pull/2065

because now ES doesnt get its piece of the pie: `Warning  FailedScheduling   2m7s (x237 over 19h)   default-scheduler   0/3 nodes are available: 1 Insufficient cpu, 2 Insufficient memory. preemption: 0/3 nodes are available: 3 No preemption victims found for incoming pod.`

