### PR TITLE
increase argo controller memory requests

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -42,10 +42,10 @@ configs:
 controller:
   resources:
    limits:
-     memory: 512Mi
+     memory: 700Mi
    requests:
      cpu: 250m
-     memory: 256Mi
+     memory: 512Mi
 
 applicationSet:
   resources:

--- a/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/argo-cd-base.values.yaml.gotmpl
@@ -8,10 +8,10 @@ dex:
 controller:
   resources:
    limits:
-     memory: 512Mi
+     memory: 700Mi
    requests:
      cpu: 250m
-     memory: 256Mi
+     memory: 512Mi
 
 notifications:
   resources:


### PR DESCRIPTION
As seen in #2068 the average argo controller memory usage actually exceeded the requests, so here's an adjustment 
![image](https://github.com/user-attachments/assets/08b73617-1e8e-4bb0-bde4-11949cf242cd)
(screenshot from wbaas-3)