### PR TITLE
Revert "prod(tf): add node pool without highthroughput logging"

### DIFF
--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -58,39 +58,3 @@ resource "google_container_node_pool" "wbaas-3_compute-pool-2" {
     max_unavailable = 0
   }
 }
-
-resource "google_container_node_pool" "wbaas-3_compute-pool-3" {
-  cluster    = google_container_cluster.wbaas-3.name
-  name       = "compute-pool-3"
-  node_count = 3
-  node_locations = [
-    "europe-west3-a",
-  ]
-  node_config {
-    disk_size_gb = 64
-    disk_type    = "pd-ssd"
-    machine_type = "n2-highmem-16"
-    metadata = {
-      "disable-legacy-endpoints" = "true"
-    }
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-      "https://www.googleapis.com/auth/service.management.readonly",
-      "https://www.googleapis.com/auth/servicecontrol",
-      "https://www.googleapis.com/auth/trace.append",
-    ]
-    preemptible     = false
-    service_account = "default"
-    shielded_instance_config {
-      enable_integrity_monitoring = true
-      enable_secure_boot          = false
-    }
-    logging_variant = "DEFAULT"
-  }
-  upgrade_settings {
-    max_surge       = 1
-    max_unavailable = 0
-  }
-}


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#2074

This also doesn't work:
```
google_container_node_pool.wbaas-3_compute-pool-3: Creating...
╷
│ Error: error creating NodePool: googleapi: Error 404: Not found: projects/wikibase-cloud/locations/europe-west3/clusters/wbaas-3.
│ Details:
│ [
│   {
│     "@type": "type.googleapis.com/google.rpc.RequestInfo",
│     "requestId": "0xc20a89de1cda02ea"
│   }
│ ]
│ , notFound
│
│   with google_container_node_pool.wbaas-3_compute-pool-3,
│   on cluster.tf line 62, in resource "google_container_node_pool" "wbaas-3_compute-pool-3":
│   62: resource "google_container_node_pool" "wbaas-3_compute-pool-3" {
│
╵
make: *** [Makefile:92: apply-production] Error 1
```