### PR TITLE
prod(tf): add node pool without highthroughput logging

### DIFF
--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -58,3 +58,39 @@ resource "google_container_node_pool" "wbaas-3_compute-pool-2" {
     max_unavailable = 0
   }
 }
+
+resource "google_container_node_pool" "wbaas-3_compute-pool-3" {
+  cluster    = google_container_cluster.wbaas-3.id
+  name       = "compute-pool-3"
+  node_count = 3
+  node_locations = [
+    "europe-west3-a",
+  ]
+  node_config {
+    disk_size_gb = 64
+    disk_type    = "pd-ssd"
+    machine_type = "n2-highmem-16"
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+    preemptible     = false
+    service_account = "default"
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = false
+    }
+    logging_variant = "DEFAULT"
+  }
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+}


### PR DESCRIPTION
This patch adds a new identical node pool to production without highthroughput logging.

We have very rarely in the last 2 weeks exceeded the 100KiB/s limit for the default logging.

Let's try to return to this and see if we can reduce the logspam.

This patch will be followed up with a second one to remove the old node pool

This patch tweaks the cluster of the node pool to be specified by the complete cluster id e.g. projects/wikibase-cloud/locations/europe-west3-a/clusters/wbaas-2 rather than just the name.

This is actually now the format in the docs [0]

[0] https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#example-usage---using-a-separately-managed-node-pool-recommended

Bug: T390698
