### PR TITLE
tf(staging): specify cluster by id not name

### DIFF
--- a/tf/env/staging/cluster.tf
+++ b/tf/env/staging/cluster.tf
@@ -21,7 +21,7 @@ resource "google_container_cluster" "wbaas-2" {
 }
 
 resource "google_container_node_pool" "wbaas-2_compute-pool-2" {
-  cluster    = "wbaas-2"
+  cluster    = google_container_cluster.wbaas-2.id
   name       = "compute-pool-2"
   node_count = 3
   node_locations = [


### PR DESCRIPTION
This is a no-op that more precisely specifies the cluster to be used by the node pool as per the docs[0]

[0] https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_node_pool#example-usage---using-a-separately-managed-node-pool-recommended

discovered after #2076

Bug: T390698
