### PR TITLE
prod(tf): try n4-highmem-8 node pool

### DIFF
--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -58,3 +58,39 @@ resource "google_container_node_pool" "wbaas-3_compute-pool-3" {
     max_unavailable = 0
   }
 }
+
+resource "google_container_node_pool" "wbaas-3_compute-pool-4" {
+  cluster    = google_container_cluster.wbaas-3.id
+  name       = "compute-pool-4"
+  node_count = 3
+  node_locations = [
+    "europe-west3-a",
+  ]
+  node_config {
+    disk_size_gb = 64
+    disk_type    = "hyperdisk-balanced"
+    machine_type = "n4-highmem-8"
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+    preemptible     = false
+    service_account = "default"
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = false
+    }
+    logging_variant = "DEFAULT"
+  }
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+}


### PR DESCRIPTION
To try and reduce costs we could try a smaller cluster and a new (n4) cpu type.

This commit does make both changes at once but that will mean less downtime while we rotate nodes than trying each option independently.

For reference at this moment wbaas-3 has a peak of 4.73 vcpu request on one node and a 42.2GB mem request on another so this should still leave us with quite some headroom

This uses the new hyperdisk vs pd-standard disk type as required by n4

Bug: T390698