### PR TITLE
Revert "prod(tf): remove old n2 node pool"

### DIFF
--- a/tf/env/production/cluster.tf
+++ b/tf/env/production/cluster.tf
@@ -23,6 +23,42 @@ resource "google_container_cluster" "wbaas-3" {
 # Be careful altering node pools. If your change results in recreation then there will be a time
 # when there are no nodes in the pool. You may wish to create a new node pool first and then
 # delete the old one.
+resource "google_container_node_pool" "wbaas-3_compute-pool-3" {
+  cluster    = google_container_cluster.wbaas-3.id
+  name       = "compute-pool-3"
+  node_count = 3
+  node_locations = [
+    "europe-west3-a",
+  ]
+  node_config {
+    disk_size_gb = 64
+    disk_type    = "pd-ssd"
+    machine_type = "n2-highmem-16"
+    metadata = {
+      "disable-legacy-endpoints" = "true"
+    }
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/service.management.readonly",
+      "https://www.googleapis.com/auth/servicecontrol",
+      "https://www.googleapis.com/auth/trace.append",
+    ]
+    preemptible     = false
+    service_account = "default"
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = false
+    }
+    logging_variant = "DEFAULT"
+  }
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+}
+
 resource "google_container_node_pool" "wbaas-3_compute-pool-4" {
   cluster    = google_container_cluster.wbaas-3.id
   name       = "compute-pool-4"


### PR DESCRIPTION
Reverts wmde/wbaas-deploy#2082

SQL and Redis failing to come up

```
vc-b2c41f80-5c5d-4909-87a5-1af2599801f9" : rpc error: code = InvalidArgument desc = Failed to Attach: failed when waiting for zonal op: rpc error: code = InvalidArgument desc = operation operation-1744366839499-6327e0dd38905-8ec8c388-a57b5eb6 failed (UNSUPPORTED_OPERATION): [pd-ssd, n4-highmem-8] features are not compatible for creating instance
```