### PR TITLE
tf: lower sql disk alert threshold to 70%

### DIFF
--- a/tf/modules/monitoring/sql-pv.tf
+++ b/tf/modules/monitoring/sql-pv.tf
@@ -1,5 +1,5 @@
 locals {
-  sql_pv_critical_utilization_threshold = 0.85 # 85%, alert triggers if metric is above this value
+  sql_pv_critical_utilization_threshold = 0.7 # 70%, alert triggers if metric is above this value
 }
 
 resource "google_monitoring_alert_policy" "alert_policy_sql_primary_pv_critical_utilization" {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T390823
https://phabricator.wikimedia.org/T390566

In a post-mortem around the recent database outage a decision was made to lower the threshold of the sql pv utilization alert to 70%: https://docs.google.com/document/d/1iP1Gf1CNTvl7beV0NJvMzXtbczGpWkKoH8Hcmc5gg5w/edit?tab=t.0


