### PR TITLE
prod(k8s): reduce redis cpu requests

### DIFF
--- a/k8s/argocd/production/redis-2.values.yaml
+++ b/k8s/argocd/production/redis-2.values.yaml
@@ -25,10 +25,9 @@ master:
     subPath: ""
   resources:
     limits:
-      cpu: 500m
       memory: 500Mi
     requests:
-      cpu: 500m
+      cpu: 30m
       memory: 500Mi
 redisPort: 6379
 replica:
@@ -45,7 +44,7 @@ replica:
     limits:
       memory: 250Mi
     requests:
-      cpu: 500m
+      cpu: 60m
       memory: 250Mi
 sentinel:
   enabled: false

--- a/k8s/argocd/production/redis.values.yaml
+++ b/k8s/argocd/production/redis.values.yaml
@@ -27,7 +27,7 @@ master:
     limits:
       memory: 500Mi
     requests:
-      cpu: 500m
+      cpu: 20m
       memory: 500Mi
 redisPort: 6379
 replica:
@@ -44,7 +44,7 @@ replica:
     limits:
       memory: 250Mi
     requests:
-      cpu: 500m
+      cpu: 13m
       memory: 250Mi
 sentinel:
   enabled: false

--- a/k8s/helmfile/env/production/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/redis.values.yaml.gotmpl
@@ -21,7 +21,7 @@ master:
     storageClass: premium-rwo
   resources:
     requests:
-      cpu: 500m
+      cpu: 20m
       memory: 500Mi
     # Internal limit is 75MB, this for now just stops runaway redis..
     limits:
@@ -39,7 +39,7 @@ replica:
     storageClass: premium-rwo
   resources:
     requests:
-      cpu: 500m
+      cpu: 13m
       memory: 250Mi
     limits:
       memory: 250Mi


### PR DESCRIPTION
Values determined by looking at last 2 weeks resource utilisation data and selecting a value near the peak.

Also removes an errant cpu limit on the redis-2 master

Bug: T390698
