### PR TITLE
prod(k8s): reduce ES cpu requests

### DIFF
--- a/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/elasticsearch-2.values.yaml.gotmpl
@@ -16,7 +16,7 @@ master:
   heapSize: 4000m
   resources:
     requests:
-      cpu: "300m"
+      cpu: "15m"
       memory: "8Gi"
     limits:
       cpu: null
@@ -40,7 +40,7 @@ data:
   heapSize: 8000m
   resources:
     requests:
-      cpu: "300m"
+      cpu: "100m"
       memory: "18Gi"
     limits:
       cpu: null


### PR DESCRIPTION
Values determined by looking at last 2 weeks resource utilisation data and selecting a value near the peak.

Bug: T390698