### PR TITLE
Revert "staging/local: use api image 10x.19.0 (#2106)"

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -57,7 +57,7 @@ app:
     tracingEnabled: false
   url: https://www.wbaas.dev
 image:
-  tag: 10x.19.0
+  tag: 10x.18.11
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/argocd/staging/api.values.yaml
+++ b/k8s/argocd/staging/api.values.yaml
@@ -56,7 +56,7 @@ app:
     tracingEnabled: false
   url: https://www.wikibase.dev
 image:
-  tag: 10x.19.0
+  tag: 10x.18.11
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 10x.19.0
+  tag: 10x.18.11
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: 10x.19.0
+  tag: 10x.18.11
 
 replicaCount:
   web: 1


### PR DESCRIPTION
This reverts commit 8be64cd542fdb139efe1e9be1bb627c5e1eeddff.


```
  Normal   Scheduled  70s                default-scheduler  Successfully assigned default/api-pre-install-artisan-setup-2cjm9 to gke-wbaas-2-compute-pool-2-ee90b82c-hg54            
  Normal   Pulling    29s (x3 over 70s)  kubelet            Pulling image "ghcr.io/wbstack/api:10x.19.0"                                                                             
  Warning  Failed     29s (x3 over 69s)  kubelet            Failed to pull image "ghcr.io/wbstack/api:10x.19.0": rpc error: code = NotFound desc = failed to pull and unpack image "g
hcr.io/wbstack/api:10x.19.0": failed to resolve reference "ghcr.io/wbstack/api:10x.19.0": ghcr.io/wbstack/api:10x.19.0: not found                                                    
  Warning  Failed     29s (x3 over 69s)  kubelet            Error: ErrImagePull                                                                                                      
  Normal   BackOff    13s (x3 over 69s)  kubelet            Back-off pulling image "ghcr.io/wbstack/api:10x.19.0"                                                                    
  Warning  Failed     13s (x3 over 69s)  kubelet            Error: ImagePullBackOff    
```

