### PR TITLE
use cloud-clusterissuers chart v0.3.1 everywhere

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -79,7 +79,7 @@ releases:
   - name: clusterissuers
     namespace: cert-manager
     chart: wbstack/wikibase-cloud-clusterissuers
-    version: 0.3.0
+    version: 0.3.1
     values:
       - environment: {{ .Environment.Name }}
       - email: {{ .Values.external.letsencrypt.email }}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T395231

- requires https://github.com/wbstack/charts/pull/194
- should be merged after https://github.com/wmde/wbaas-deploy/pull/2134

