### PR TITLE
Fix local terraform dependencies

### DIFF
--- a/tf/env/local/secrets-recaptcha.tf
+++ b/tf/env/local/secrets-recaptcha.tf
@@ -1,5 +1,9 @@
 resource "kubernetes_secret" "recaptcha-v3-secrets" {
-  for_each = toset(["default", "api-jobs", "adhoc-jobs"])
+  for_each = toset([
+    "default",
+    kubernetes_namespace.api-job-namespace.metadata[0].name,
+    kubernetes_namespace.adhoc-job-namespace.metadata[0].name,
+  ])
   metadata {
     name = "recaptcha-v3-secrets"
     # default as staging
@@ -18,7 +22,11 @@ moved {
 }
 
 resource "kubernetes_secret" "recaptcha-v2-secrets" {
-  for_each = toset(["default", "api-jobs", "adhoc-jobs"])
+  for_each = toset([
+    "default",
+    kubernetes_namespace.api-job-namespace.metadata[0].name,
+    kubernetes_namespace.adhoc-job-namespace.metadata[0].name,
+  ])
   metadata {
     name = "recaptcha-v2-secrets"
     # default as staging

--- a/tf/env/local/secrets-sql.tf
+++ b/tf/env/local/secrets-sql.tf
@@ -8,7 +8,11 @@ resource "random_password" "sql-passwords" {
 
 # Used by the sql service for initial setup
 resource "kubernetes_secret" "sql-secrets-passwords" {
-  for_each = toset(["default", "api-jobs", "adhoc-jobs"])
+  for_each = toset([
+    "default",
+    kubernetes_namespace.api-job-namespace.metadata[0].name,
+    kubernetes_namespace.adhoc-job-namespace.metadata[0].name,
+  ])
   metadata {
     name      = "sql-secrets-passwords"
     namespace = each.value
@@ -39,7 +43,6 @@ resource "kubernetes_secret" "sql-secrets-init-passwords" {
     "SQL_INIT_PASSWORD_BACKUPS" = base64encode(random_password.sql-passwords["backup-manager"].result)
     "SQL_INIT_OBSERVER"         = base64encode(random_password.sql-passwords["observer"].result)
   }
-
 }
 
 moved {


### PR DESCRIPTION
During initial setup of development environment, `tofu apply` resulted in a `Error: namespaces "adhoc-jobs" not found`. Given that `resource "kubernetes_namespace" "adhoc-job-namespace"` exists, I assumed this was simply because resources tried to use the "adhoc-jobs" namespace before it had been created. Explicitly defining the dependency resolved the issue.
