### PR TITLE
k8s(ingress-nginx): tighten per site rate limits

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -11,8 +11,8 @@ controller:
       cpu: null
   config:
     http-snippet: >-
-      limit_req_zone $host zone=limit_host:10m rate=15r/s;
-      limit_req zone=limit_host burst=40 delay=10;
+      limit_req_zone $host zone=limit_host:10m rate=10r/s;
+      limit_req zone=limit_host burst=20 delay=10;
       limit_req_zone $binary_remote_addr$host zone=limit_ip_host:10m rate=5r/s;
       limit_req zone=limit_ip_host burst=30 delay=10;
     limit-req-status-code: 429


### PR DESCRIPTION
We're seeing a number of sites now bumping off the limiter and that's still enough to take the DB down.

This patch drops it back down again

Bug: T399439

