### PR TITLE
use api chart 0.33.0 on production

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -145,10 +145,14 @@ trustedProxy:
     - '*'
 useProbes: true
 wbstack:
+  complaint:
+    mail:
+      recipient: someone@wikimedia.de
+      sender: dsa@wbaas.dev
   contact:
     mail:
       recipient: someone@wikimedia.de
-      sender: contact-<subject>@wikibase.cloud
+      sender: contact-<subject>@wbaas.dev
   elasticSearch:
     enabledByDefault: true
   maxWikisPerUser: null

--- a/k8s/argocd/local/app-of-apps.values.yaml
+++ b/k8s/argocd/local/app-of-apps.values.yaml
@@ -1,5 +1,5 @@
 chartVersions:
   wbaasUi: 0.4.0
-  wbaasApi: 0.32.1
+  wbaasApi: 0.33.0
   redis: 17.3.8
   redis2: 19.6.4

--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -139,6 +139,10 @@ trustedProxy:
     - 10.108.0.0/14
 useProbes: true
 wbstack:
+  complaint:
+    mail:
+      recipient: dsa-meldung@wikimedia.de
+      sender: dsa@wikibase.cloud
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/argocd/production/app-of-apps.values.yaml
+++ b/k8s/argocd/production/app-of-apps.values.yaml
@@ -1,5 +1,5 @@
 chartVersions:
   wbaasUi: 0.4.0
-  wbaasApi: 0.32.1
+  wbaasApi: 0.33.0
   redis: 17.3.8
   redis2: 19.6.4

--- a/k8s/argocd/staging/api.values.yaml
+++ b/k8s/argocd/staging/api.values.yaml
@@ -140,6 +140,10 @@ trustedProxy:
     - 10.112.0.0/14
 useProbes: true
 wbstack:
+  complaint:
+    mail:
+      recipient: wikibase-cloud@wikimedia.de
+      sender: dsa@wikibase.dev
   contact:
     mail:
       recipient: contact.wikibase@wikimedia.de

--- a/k8s/argocd/staging/app-of-apps.values.yaml
+++ b/k8s/argocd/staging/app-of-apps.values.yaml
@@ -1,5 +1,5 @@
 chartVersions:
   wbaasUi: 0.4.0
-  wbaasApi: 0.32.1
+  wbaasApi: 0.33.0
   redis: 17.3.8
   redis2: 19.6.4

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -16,7 +16,11 @@ wbstack:
   contact:
     mail:
       recipient: someone@wikimedia.de
-      sender: contact-<subject>@wikibase.cloud
+      sender: contact-<subject>@wbaas.dev
+  complaint:
+    mail:
+      recipient: someone@wikimedia.de
+      sender: dsa@wbaas.dev
 
 app:
   name: WBaaS Localhost

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -72,6 +72,10 @@ wbstack:
     mail:
       recipient: contact.wikibase@wikimedia.de
       sender: contact-<subject>@wikibase.cloud
+  complaint:
+    mail:
+      recipient: dsa-meldung@wikimedia.de
+      sender: dsa@wikibase.cloud
 
 app:
   name: WBaaS Wikibase Production

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -26,6 +26,10 @@ wbstack:
     mail:
       recipient: contact.wikibase@wikimedia.de
       sender: contact-<subject>@wikibase.dev
+  complaint:
+    mail:
+      recipient: wikibase-cloud@wikimedia.de
+      sender: dsa@wikibase.dev
 
 app:
   name: WBaaS Wikibase Dev


### PR DESCRIPTION
note: this just adds configuration values and does not reploy a new api image

depends on
* https://github.com/wbstack/charts/pull/195
* https://github.com/wmde/wbaas-deploy/pull/2188

- **use api chart 0.33.0 on production**

