### PR TITLE
Add Alibaba DC ips to very tight rate limit

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -11,6 +11,34 @@ controller:
       cpu: null
   config:
     http-snippet: >-
+      geo $limit_from_cloud_provider {
+        default 0;
+
+        # AL-3; https://networksdb.io/ips-in-network/47.74.0.0/47.87.255.255
+        47.74.0.0/24 1;
+        47.75.0.0/24 1;
+        47.76.0.0/24 1;
+        47.77.0.0/24 1;
+        47.78.0.0/24 1;
+        47.79.0.0/24 1;
+        47.80.0.0/24 1;
+        47.81.0.0/24 1;
+        47.82.0.0/24 1;
+        47.83.0.0/24 1;
+        47.84.0.0/24 1;
+        47.85.0.0/24 1;
+        47.86.0.0/24 1;
+        47.87.0.0/24 1;
+      }
+
+      map $limit_from_cloud_provider $tight_limit_key {
+        0 "";
+        1 "fromcloud";
+      }
+
+      limit_req_zone $tight_limit_key zone=cloud_provider:10m rate=5r/s;
+      limit_req zone=cloud_provider burst=20 nodelay;
+
       limit_req_zone $host zone=limit_host:10m rate=10r/s;
       limit_req zone=limit_host burst=20 delay=10;
       limit_req_zone $binary_remote_addr$host zone=limit_ip_host:10m rate=5r/s;


### PR DESCRIPTION
This add a new limit_req_zone that only applies to ips in a list of CIDRs. This is done by specifying a `geo`[1] and a `map`[2] that work in conjunction to limit all of these requests together rather than treat them as separate ips.

[1] https://nginx.org/en/docs/http/ngx_http_geo_module.html
[2] https://nginx.org/en/docs/http/ngx_http_map_module.html

Bug: T400046

