### PR TITLE
k8s: ingress-nginx make cloud zone limits super tight

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -36,8 +36,8 @@ controller:
         1 "fromcloud";
       }
 
-      limit_req_zone $tight_limit_key zone=cloud_provider:10m rate=5r/s;
-      limit_req zone=cloud_provider burst=20 nodelay;
+      limit_req_zone $tight_limit_key zone=cloud_provider:10m rate=1r/s;
+      limit_req zone=cloud_provider nodelay;
 
       limit_req_zone $host zone=limit_host:10m rate=10r/s;
       limit_req zone=limit_host burst=20 delay=10;


### PR DESCRIPTION
Drop the limits to be even tighter. Allow no bursting and no delay. Also drop the limit to 1/s. This should cause us to drop most of these requests.

Bug: T400046
