### PR TITLE
Ignore Accept-Encoding for MediaWiki version routing

### DIFF
--- a/k8s/helmfile/env/local/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/local/platform-nginx.nginx.conf
@@ -91,6 +91,8 @@ server {
                 proxy_cache_key $host;
                 proxy_cache_valid any 5m;
                 proxy_ignore_headers Cache-Control;
+                proxy_ignore_headers Vary;
+                proxy_set_header Accept-Encoding "";
                 add_header X-Cache-Status $upstream_cache_status;
 	}
 

--- a/k8s/helmfile/env/production/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/production/platform-nginx.nginx.conf
@@ -252,6 +252,8 @@ server {
                 proxy_cache_key $host;
                 proxy_cache_valid any 5m;
                 proxy_ignore_headers Cache-Control;
+                proxy_ignore_headers Vary;
+                proxy_set_header Accept-Encoding "";
                 add_header X-Cache-Status $upstream_cache_status;
 	}
 

--- a/k8s/helmfile/env/staging/platform-nginx.nginx.conf
+++ b/k8s/helmfile/env/staging/platform-nginx.nginx.conf
@@ -106,6 +106,8 @@ server {
                 proxy_cache_key $host;
                 proxy_cache_valid any 5m;
                 proxy_ignore_headers Cache-Control;
+                proxy_ignore_headers Vary;
+                proxy_set_header Accept-Encoding "";
                 add_header X-Cache-Status $upstream_cache_status;
 	}
 


### PR DESCRIPTION
It’s possible that sending a request to MediaWiki with a different `Accept-Encoding` header causes Nginx to force a cache MISS for its `/version` lookup. This can be mitigated by configuring Nginx to ignore the `Vary` header returned by the Platform API, and to reset the `Accept-Encoding` header before it sends a request to the Platform API. There doesn't seem to be a way to prevent Nginx from forwarding all the headers by default.

[1] https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Accept-Encoding
[2] https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Vary
[3] https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_ignore_headers
[4] https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header
