### PR TITLE
Use wbstack mirror for Bitnami legacy charts

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -5,7 +5,7 @@ repositories:
     url: https://charts.bitnami.com/bitnami
   - name: bitnami-legacy
     # yamllint disable-line rule:line-length
-    url: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    url: https://raw.githubusercontent.com/wbstack/bitnami-legacy/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   - name: cetic
     url: https://cetic.github.io/helm-charts
   - name: codecentric


### PR DESCRIPTION
Bug: [T401478](https://phabricator.wikimedia.org/T401478)
