### PR TITLE
Use wbstack mirror for Bitnami charts used by Helmfile

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -3,10 +3,7 @@ repositories:
     url: https://wbstack.github.io/charts
   - name: bitnami-legacy
     # yamllint disable-line rule:line-length
-    url: https://raw.githubusercontent.com/wbstack/bitnami-legacy/ed0cf51bf0d2f21a99dda8269b806d2a20648986/bitnami
-  - name: bitnami-legacy-pre-2022
-    # yamllint disable-line rule:line-length
-    url: https://raw.githubusercontent.com/wbstack/bitnami-legacy/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
+    url: https://raw.githubusercontent.com/wbstack/bitnami-legacy/14b6efaa84c7ed5684885ca8d29479fe6e3ed973/bitnami
   - name: cetic
     url: https://cetic.github.io/helm-charts
   - name: codecentric
@@ -123,7 +120,7 @@ releases:
 
   - name: sql
     namespace: default
-    chart: bitnami-legacy-pre-2022/mariadb
+    chart: bitnami-legacy/mariadb
     version: 10.5.0
     <<: *default_release
 
@@ -135,7 +132,7 @@ releases:
 
   - name: platform-nginx
     namespace: default
-    chart: bitnami-legacy-pre-2022/nginx
+    chart: bitnami-legacy/nginx
     version: 5.2.4
     <<: *default_release
 


### PR DESCRIPTION
Bug: [T401478](https://phabricator.wikimedia.org/T401478)
