### PR TITLE
Use wbstack mirror for Redis image on production

### DIFF
--- a/k8s/argocd/production/redis-2.values.yaml
+++ b/k8s/argocd/production/redis-2.values.yaml
@@ -1,3 +1,7 @@
+image:
+  registry: ghcr.io
+  repository: wbstack/redis
+  tag: 7.2.5-debian-12-r4
 architecture: replication
 auth:
   enabled: true

--- a/k8s/argocd/production/redis.values.yaml
+++ b/k8s/argocd/production/redis.values.yaml
@@ -14,6 +14,10 @@ commonConfiguration: |
   # Auto AOF file rewriting
   auto-aof-rewrite-percentage 100
   auto-aof-rewrite-min-size 85mb
+image:
+  registry: ghcr.io
+  repository: wbstack/redis
+  tag: 7.0.5-debian-11-r15
 master:
   persistence:
     accessModes:

--- a/k8s/helmfile/env/production/redis.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/redis.values.yaml.gotmpl
@@ -1,3 +1,8 @@
+image:
+  registry: ghcr.io
+  repository: wbstack/redis
+  tag: 7.0.5-debian-11-r15
+
 redisPort: 6379
 
 architecture: "replication"


### PR DESCRIPTION
Bug: [T401478](https://phabricator.wikimedia.org/T401478)
