### PR TITLE
Bump resources for ArgoCD's repoServer

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -76,8 +76,8 @@ repoServer:
    limits:
      memory: 1024Mi
    requests:
-     cpu: 10m
-     memory: 64Mi
+     cpu: 250m
+     memory: 128Mi
 
 server:
   resources:


### PR DESCRIPTION
Bug: [T401478](https://phabricator.wikimedia.org/T401478)
