### PR TITLE
local: helper script for firefox CA cert install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,12 @@ local-ca:
 	kubectl get secret wikibase-local-tls -o json | jq -r '.data."ca.crt"' | base64 -d > wikibase-local-ca.crt
 	realpath wikibase-local-ca.crt
 
+
+.PHONY: local-ca-firefox
+local-ca-firefox: # @HELP Install the minikube cluster CA certificate into your firefox profile ($FIREFOX_PROFILE)
+local-ca-firefox:
+	./bin/local/install-ca-cert-firefox.sh
+
 .PHONY: minikube-start
 minikube-start: # @HELP Start a local k8s cluster using minikube
 minikube-start:

--- a/bin/local/install-ca-cert-firefox.sh
+++ b/bin/local/install-ca-cert-firefox.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Installs (and replaces) the current local minikube CA certificate into your firefox profile
+# FIREFOX_PROFILE needs to be set, for example via direnv or ~/.profile
+#
+# With 'ls -lt ~/.mozilla/firefox/' it should be possible to find out which is your currently used profile 
+# when comparing the modification dates of the directories (latest one = that's probably it)
+#
+# If this script fails with something like 'dial tcp [::1]:8080: connect: connection refused"'
+# make sure that your minikube cluster is running and initialized
+#
+
+### failsafe logic to exit in case we are not running in our local minikube context
+KUBE_CONTEXT=$(kubectl config current-context)
+
+echo "Current kube context: '${KUBE_CONTEXT}'"
+
+if [[ "${KUBE_CONTEXT}" != "minikube-wbaas" ]]; then
+    echo "Error: wrong kube context. Use this script only within 'minikube-wbaas'!"
+    exit 1
+fi
+
+if [[ -z "${FIREFOX_PROFILE}" || ! -d "${FIREFOX_PROFILE}" ]]; then
+  echo "Please set '\$FIREFOX_PROFILE', should look something like ~/.mozilla/firefox/1234.default"
+  echo "Current value: '${FIREFOX_PROFILE}'"
+  exit 2
+fi
+
+set -euo pipefail
+
+FIREFOX_PROFILE=$(realpath "${FIREFOX_PROFILE}")
+CERT_NAME='wikibase-local-root-ca'
+CERT_PATH="/tmp/wikibase-local-ca.crt"
+
+kubectl get secret wikibase-local-tls -o json | jq -r '.data."ca.crt"' | base64 -d > "${CERT_PATH}"
+
+certutil -d sql:"${FIREFOX_PROFILE}" -D -n "${CERT_NAME}" 
+certutil -d sql:"${FIREFOX_PROFILE}" -A -n "${CERT_NAME}" -t 'C,,' -i "${CERT_PATH}"
+certutil -d sql:"${FIREFOX_PROFILE}" -L -n "${CERT_NAME}"
+
+echo "Certificate successfully installed."

--- a/bin/local/install-ca-cert-firefox.sh
+++ b/bin/local/install-ca-cert-firefox.sh
@@ -34,7 +34,6 @@ CERT_PATH="/tmp/wikibase-local-ca.crt"
 
 kubectl get secret wikibase-local-tls -o json | jq -r '.data."ca.crt"' | base64 -d > "${CERT_PATH}"
 
-certutil -d sql:"${FIREFOX_PROFILE}" -D -n "${CERT_NAME}" 
 certutil -d sql:"${FIREFOX_PROFILE}" -A -n "${CERT_NAME}" -t 'C,,' -i "${CERT_PATH}"
 certutil -d sql:"${FIREFOX_PROFILE}" -L -n "${CERT_NAME}"
 

--- a/bin/local/new-local-cluster.sh
+++ b/bin/local/new-local-cluster.sh
@@ -42,6 +42,10 @@ helmfile --environment local sync
 # https://github.com/wbstack/charts/blob/main/charts/api/templates/pre-install-job.yaml#L39
 #kubectl exec -ti deployments/api-app-backend -- bash -c 'php artisan migrate:install; php artisan migrate --force; php artisan passport:client --personal --no-interaction; php artisan passport:client --password --no-interaction'
 
+if [[ -d "${FIREFOX_PROFILE}" ]]; then
+  "$WBAAS_DEPLOY_DIR/bin/local/install-ca-cert-firefox.sh"
+fi
+
 echo
 echo "Finished re-initializing local cluster."
 echo "To also create a local user account, open the minikube tunnel and run './bin/local/create-local-user.sh'."

--- a/doc/local-dev-env.md
+++ b/doc/local-dev-env.md
@@ -205,7 +205,10 @@ More detailed information on the load balancer can be found in [minikube-load-ba
 Since we [introduced](https://phabricator.wikimedia.org/T378691) using HTTPS for local ingresses, you will get a scary warning when accessing local web interfaces. This can be mitigated by trusting the local CA certificate that is getting used for self-signing. The easiest way to do this is to save the local CA certificate in a file by accessing the secret it lives in (`wikibase-local-tls`) and importing it in your browser settings. There is also the possibility to import it into the trust store of your operating system, for example via the tool [mkcert](https://github.com/FiloSottile/mkcert), but you should be aware of the possible consequences this could have for the security of your machine.
 
 > [!TIP]
-> Running `make local-ca` will save the certificate to the file `wikibase-local-tls.crt`. It is highly recommended to delete the file again after importing it.
+> Running `make local-ca-firefox` will import the current certificate automatically into your firefox profile, if you have set `FIREFOX_PROFILE`. See [install-ca-cert-firefox.sh](/bin/local/install-ca-cert-firefox.sh)
+
+> [!TIP]
+> Running `make local-ca` will save the certificate to the file `wikibase-local-tls.crt`.
 
 > [!NOTE]
 > If you recreate your local cluster, you have to re-import the CA certificate, as a new one will get generated and used instead.


### PR DESCRIPTION
This adds a new script for local use that automatically installs the current minikube cluster CA certificate into your firefox profile. To make it work, you need to set the env var `FIREFOX_PROFILE` to your currently used firefox profile (a peek into `~/.mozilla/firefox` should reveal which is your the right one, probably the last one modified). Add it to your .envrc if you use [direnv](https://direnv.net/) or add it otherwise to your shell session, for example via the file `~/.profile`

- also this script runs now with new-cluster.sh, if env var is set

Use it via `./bin/local/install-ca-cert-firefox.sh` or simply `make local-ca-firefox`
