### PR TITLE
argocd: lower reconciliation time

### DIFF
--- a/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/argo-cd-base.values.yaml.gotmpl
@@ -11,6 +11,8 @@ configs:
     users.anonymous.enabled: true
     admin.enabled: false
 
+    timeout.reconciliation: 60s
+
     ui.bannerpermanent: true
     ui.bannerposition: "top"
     ui.bannercontent: "PRODUCTION"


### PR DESCRIPTION
I noticed the default setting is 3 minutes (180s), which means "worst case" after you merge something you still need to wait some time.

I think lowering it to 60 seconds will make it a bit more useful. Maybe we can look into using a webhook here in the future.

https://github.com/argoproj/argo-helm/tree/main/charts/argo-cd#general-parameters

