### PR TITLE
lint: disable line length rule in yamllint

### DIFF
--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -7,8 +7,7 @@ rules:
     min-spaces-inside-empty: 0
     max-spaces-inside-empty: 0
   braces: disable # template curlies (`{{ someValue }}`) make this rule unhappy
-  line-length:
-    max: 100
+  line-length: disable
 
 # Despite being .yaml files, a lot of what's in templates/ isn't valid YAML
 ignore: |

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -2,7 +2,6 @@ repositories:
   - name: wbstack
     url: https://wbstack.github.io/charts
   - name: bitnami-legacy
-    # yamllint disable-line rule:line-length
     url: https://raw.githubusercontent.com/wbstack/bitnami-legacy/14b6efaa84c7ed5684885ca8d29479fe6e3ed973/bitnami
   - name: cetic
     url: https://cetic.github.io/helm-charts

--- a/k8s/helmfile/only-for-argo-value-generation.yaml
+++ b/k8s/helmfile/only-for-argo-value-generation.yaml
@@ -4,7 +4,6 @@ repositories:
   - name: bitnami
     url: https://charts.bitnami.com/bitnami
   - name: bitnami-legacy
-    # yamllint disable-line rule:line-length
     url: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
   - name: cetic
     url: https://cetic.github.io/helm-charts


### PR DESCRIPTION
There is little value on enforcing a line limit rule. A lot of our yaml files contain URLs which often exceeded the rule.