### PR TITLE
(staging/local) helmfile: re-add redis deployments

### DIFF
--- a/k8s/helmfile/env/local/argocd-config.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/argocd-config.values.yaml.gotmpl
@@ -1,2 +1,2 @@
 environment: local
-appOfAppsVersion: 2.0.1
+appOfAppsVersion: 2.1.0

--- a/k8s/helmfile/env/local/redis-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/redis-2.values.yaml.gotmpl
@@ -1,0 +1,46 @@
+image:
+  registry: ghcr.io
+  repository: wbstack/redis
+  tag: 7.2.5-debian-12-r4
+
+commonConfiguration: |
+  # Enable AOF https://redis.io/topics/persistence#append-only-file
+  appendonly yes
+  # Disable RDB persistence, AOF persistence already enabled.
+  save ""
+  # Control memory usage
+  maxmemory 50mb
+  maxmemory-policy volatile-lru
+  # Auto AOF file rewriting
+  auto-aof-rewrite-percentage 100
+  auto-aof-rewrite-min-size 60mb
+
+master:
+  persistence:
+    storageClass: null
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    enabled: false
+  resources:
+    limits:
+      cpu: 50m
+      memory: 90Mi
+    requests:
+      cpu: 10m
+      memory: 62Mi
+
+replica:
+  persistence:
+    storageClass: null
+  livenessProbe:
+    enabled: false
+  readinessProbe:
+    enabled: false
+  resources:
+    limits:
+      cpu: 50m
+      memory: 90Mi
+    requests:
+      cpu: 10m
+      memory: 60Mi

--- a/k8s/helmfile/env/production/redis-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/redis-2.values.yaml.gotmpl
@@ -1,0 +1,61 @@
+image:
+  registry: ghcr.io
+  repository: wbstack/redis
+  tag: 7.2.5-debian-12-r4
+
+architecture: replication
+
+auth:
+  enabled: true
+  existingSecret: redis-password
+  existingSecretPasswordKey: password
+
+commonConfiguration: |
+  # Enable AOF https://redis.io/topics/persistence#append-only-file
+  appendonly yes
+  # Disable RDB persistence, AOF persistence already enabled.
+  save ""
+  # Control memory usage
+  maxmemory 75mb
+  maxmemory-policy volatile-lru
+  # Auto AOF file rewriting
+  auto-aof-rewrite-percentage 100
+  auto-aof-rewrite-min-size 85mb
+
+master:
+  persistence:
+    accessModes:
+      - ReadWriteOnce
+    enabled: true
+    path: /data
+    size: 1Gi
+    storageClass: premium-rwo
+    subPath: ""
+  resources:
+    limits:
+      memory: 500Mi
+    requests:
+      cpu: 30m
+      memory: 500Mi
+
+redisPort: 6379
+
+replica:
+  persistence:
+    accessModes:
+      - ReadWriteOnce
+    enabled: true
+    path: /data
+    size: 1Gi
+    storageClass: premium-rwo
+    subPath: ""
+  replicaCount: 1
+  resources:
+    limits:
+      memory: 250Mi
+    requests:
+      cpu: 60m
+      memory: 250Mi
+
+sentinel:
+  enabled: false

--- a/k8s/helmfile/env/staging/argocd-config.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/argocd-config.values.yaml.gotmpl
@@ -1,2 +1,2 @@
 environment: staging
-appOfAppsVersion: 2.0.1
+appOfAppsVersion: 2.1.0

--- a/k8s/helmfile/env/staging/redis-2.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/redis-2.values.yaml.gotmpl
@@ -1,0 +1,20 @@
+image:
+  registry: ghcr.io
+  repository: wbstack/redis
+  tag: 7.2.5-debian-12-r4
+
+master:
+  resources:
+    limits:
+      memory: 500Mi
+    requests:
+      cpu: 100m
+      memory: 500Mi
+
+replica:
+  resources:
+    limits:
+      memory: 250Mi
+    requests:
+      cpu: 100m
+      memory: 250Mi

--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -97,7 +97,7 @@ releases:
   - name: argocd-config
     namespace: argocd
     chart: wbstack/argocd-config
-    version: 2.0.1
+    version: '{{ if eq .Environment.Name "production" }} 2.0.1 {{ else }} 2.1.0 {{ end }}'
     <<: *default_release
 
   - name: redirects
@@ -223,6 +223,18 @@ releases:
     namespace: default
     chart: wbstack/superset
     version: 0.1.0
+    <<: *default_release
+
+  - name: redis
+    installed: {{ ne .Environment.Name "production" | toYaml }}
+    namespace: default
+    chart: https://github.com/wbstack/bitnami-legacy/releases/download/redis/17.3.8/redis-17.3.8.tgz
+    <<: *default_release
+
+  - name: redis-2
+    installed: {{ ne .Environment.Name "production" | toYaml }}
+    namespace: default
+    chart: https://github.com/wbstack/bitnami-legacy/releases/download/redis/19.6.4/redis-19.6.4.tgz
     <<: *default_release
 
   ################################

--- a/k8s/helmfile/only-for-argo-value-generation.yaml
+++ b/k8s/helmfile/only-for-argo-value-generation.yaml
@@ -58,9 +58,3 @@ releases:
     chart: wbstack/ui
     version: 0.3.1
     <<: *default_release
-
-  - name: redis
-    namespace: default
-    chart: bitnami/redis
-    version: 17.3.8
-    <<: *default_release


### PR DESCRIPTION
This PR re-adds redis deployments for staging/local envs and uses new argocd charts that do not deploy redis anymore.

https://phabricator.wikimedia.org/T405468
https://github.com/wbstack/charts/pull/201

