### PR TITLE
use argocd-config 2.1.2

### DIFF
--- a/k8s/helmfile/helmfile.yaml
+++ b/k8s/helmfile/helmfile.yaml
@@ -97,7 +97,7 @@ releases:
   - name: argocd-config
     namespace: argocd
     chart: wbstack/argocd-config
-    version: 2.1.1
+    version: 2.1.2
     <<: *default_release
 
   - name: redirects


### PR DESCRIPTION
https://phabricator.wikimedia.org/T405468

https://github.com/wbstack/charts/pull/203

deploying argocd-config 2.1.2 to cleanup the bitnami source repo URL

