### PR TITLE
Staging+Local: Deploy new Queryservice image 0.3.135-wbstack.8

### DIFF
--- a/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/queryservice.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "0.3.135-wbstack.7"
+  tag: "0.3.135-wbstack.8"
 useProbes: false
 
 app:

--- a/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/queryservice.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "0.3.135-wbstack.7"
+  tag: "0.3.135-wbstack.8"
 app:
   heapSize: 1g
 


### PR DESCRIPTION
This is an update for the Queryservice image in staging and local, using 0.3.135-wbstack.8

Bug: T418868
