### PR TITLE
Production: Deploy new Queryservice image 0.3.135-wbstack.8

### DIFF
--- a/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/queryservice.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: "0.3.135-wbstack.7"
+  tag: "0.3.135-wbstack.8"
   repository: ghcr.io/wbstack/queryservice
   pullPolicy: Always
 


### PR DESCRIPTION
This is an update for the Queryservice image in production, using 0.3.135-wbstack.8

Bug: [T418868](https://phabricator.wikimedia.org/T418868)