### PR TITLE
Revert to df5e715018accc4b00ee71bd982f3d0b258d2295

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -56,7 +56,7 @@ app:
     tracingEnabled: false
   url: https://www.wbaas.dev
 image:
-  tag: sha-4808a42
+  tag: sha-95bb41a
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -54,7 +54,7 @@ app:
     tracingEnabled: false
   url: https://www.wikibase.cloud
 image:
-  tag: sha-4808a42
+  tag: sha-95bb41a
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/argocd/staging/api.values.yaml
+++ b/k8s/argocd/staging/api.values.yaml
@@ -55,7 +55,7 @@ app:
     tracingEnabled: false
   url: https://www.wikibase.dev
 image:
-  tag: sha-4808a42
+  tag: sha-95bb41a
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: sha-4808a42
+  tag: sha-95bb41a
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: sha-4808a42
+  tag: sha-95bb41a
 
 replicaCount:
   web: 1

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: sha-4808a42
+  tag: sha-95bb41a
 
 replicaCount:
   web: 1


### PR DESCRIPTION
Created with `git restore --source=df13a40184035498d5873b97fe23d9c4d0a092b9 -- .` as the last known good (pre-alerts) commit.

This is before we had alerts fire related to queryservice backpressure

Bug: T423429