### PR TITLE
Use pull_request_target for mattermost.yml

### DIFF
--- a/.github/workflows/mattermost.yml
+++ b/.github/workflows/mattermost.yml
@@ -1,6 +1,8 @@
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened, reopened ]
+
+permissions: {}
 
 jobs:
   build:


### PR DESCRIPTION
Make the workflow run from the target/base branch instead of PR source branch so that it has access to repo secrets [1].

User provided PRs can not change the workflow code that is running, unless the repo is already compromised.

[1]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request_target