### PR TITLE
Improve the github PR template with instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,25 @@
-## Describe the changes
-## This is what I need help with
-## Prior discussion
+## Summary
+<!-- In 1-3 sentences: what changed and why? -->
 
-Bug: 
+## Context
+<!--
+Why is this needed now? What user/team/system impact does it have?
+If this is routine maintenance, say that explicitly.
+-->
+
+## Prior discussion
+<!--
+Link issues/Phabricator tasks/docs/ADRs/Slack threads.
+Use "None" if there is no prior discussion.
+-->
+
+## What changed
+<!-- List concrete relevant changes as bullets. -->
+- 
+
+## Bug
+<!--
+Link to a task on https://phabricator.wikimedia.org/
+If a relevant one does not exist, create one and link it here.
+Bug: T123456
+-->


### PR DESCRIPTION
## Describe the changes

This makes it clearer for people submitting PRs what
content might be desired / expected or useful,
and also bring context around what "Bug:" means for
example.

I feel like the team might want to tweak this, but
I also feel like this is a good enough start.

<!-- this should be hidden -->