### PR TITLE
Fix: fix helmfile-values script to generate correct temp files

### DIFF
--- a/bin/generate-values
+++ b/bin/generate-values
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-if [[ -n "${CI}" ]]; then
+set -euo pipefail
+
+if [[ -n "${CI:-}" ]]; then
     set -x
 fi
 
@@ -15,8 +17,8 @@ RELEASE="$2"
 
 ROOT=$(git rev-parse --show-toplevel)
 OUTPUT_TEMPLATE="${ROOT}/k8s/argocd/${ENVIRONMENT}/${RELEASE}.values.yaml"
-HELMFILE="k8s/helmfile/only-for-argo-value-generation.yaml"
-TMP_HELMFILE="$(dirname ${HELMFILE})/.tmp_helmfile.$(mktemp -u XXXXXX).yaml"
+HELMFILE="${ROOT}/k8s/helmfile/only-for-argo-value-generation.yaml"
+TMP_HELMFILE="$(dirname "${HELMFILE}")/.tmp_helmfile.$(mktemp -u XXXXXX).yaml.gotmpl"
 
 if [[ -n "$3" ]]; then
     OUTPUT_TEMPLATE="$3"

--- a/skaffold/helmfile-values
+++ b/skaffold/helmfile-values
@@ -1,10 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
 
 Help()
 {
    # Display Help
    echo "Generates a temporary local values file for a helmfile deployment."
-   echo 
+   echo
    echo "This script needs yq installed https://mikefarah.gitbook.io/yq/"
    echo
    echo "Syntax: helmfile-values [-h|e|r]"
@@ -23,7 +25,7 @@ yqtest=$(which yq)
 if [ -z "$yqtest" ]
 then
    echo "This script needs yq installed https://mikefarah.gitbook.io/yq/"
-    exit 1
+   exit 1
 fi
 
 # Set variable defaults
@@ -40,6 +42,9 @@ while getopts ":r:e:hn" option; do
          TARGET_ENVIRONMENT=$OPTARG;;
       n)
          REMOVE_IMAGE_YAML=1;;
+      h) # display Help
+         Help
+         exit;;
       *) # display Help
          Help
          exit;;
@@ -47,16 +52,24 @@ while getopts ":r:e:hn" option; do
 done
 
 SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
-OUTPUT_YAML=$SCRIPT_DIR/.tmp.values.$TARGET_RELEASE.yaml
+OUTPUT_YAML="$SCRIPT_DIR/.tmp.values.$TARGET_RELEASE.yaml"
 
 # Run the commands
 echo "Targeting environment: $TARGET_ENVIRONMENT and release: $TARGET_RELEASE"
-cd "$SCRIPT_DIR"/../k8s/helmfile && \
-helmfile --environment "$TARGET_ENVIRONMENT" --selector name="$TARGET_RELEASE" write-values --skip-deps --output-file-template "$OUTPUT_YAML"
+case "$TARGET_RELEASE" in
+   api|ui)
+      cd "$SCRIPT_DIR/.." && \
+      ./bin/generate-values "$TARGET_ENVIRONMENT" "$TARGET_RELEASE" "$OUTPUT_YAML"
+      ;;
+   *)
+      cd "$SCRIPT_DIR/../k8s/helmfile" && \
+      helmfile --environment "$TARGET_ENVIRONMENT" --selector name="$TARGET_RELEASE" write-values --skip-deps --output-file-template "$OUTPUT_YAML"
+      ;;
+esac
 
 if [[ "$REMOVE_IMAGE_YAML" == 1 ]]; then
    yq eval 'del(.image)' --no-colors "$OUTPUT_YAML" > "$OUTPUT_YAML".altered
    mv "$OUTPUT_YAML".altered "$OUTPUT_YAML"
 fi
 
-cat "$SCRIPT_DIR/.tmp.values.$TARGET_RELEASE.yaml"
+cat "$OUTPUT_YAML"


### PR DESCRIPTION
- In the `skaffold/helmfile-values` script:
  - `api` and `ui` are now handled through `./bin/generate-values` instead of `helmfile write-values` like other releases
  - Add `#!/usr/bin/env bash` and `set -euo pipefail, explicit -h` to tighten the script
  - Add `cat "$OUTPUT_YAML"` instead of rebuilding temp path string manually
- In the `bin/generate-values`:
  - Add `set -euo pipefail` and safer CI detection with `${CI:-}`
  - Resolve the Helmfile source path from the repo root
  - Use `.yaml.gotmpl` suffix for the temp Helmfile file before being passed to `helmfile --file`

Bug: T425426