### PR TITLE
skaffold: use argo values for argo services

### DIFF
--- a/bin/generate-values
+++ b/bin/generate-values
@@ -15,8 +15,9 @@ RELEASE="$2"
 
 ROOT=$(git rev-parse --show-toplevel)
 OUTPUT_TEMPLATE="${ROOT}/k8s/argocd/${ENVIRONMENT}/${RELEASE}.values.yaml"
-HELMFILE="k8s/helmfile/only-for-argo-value-generation.yaml"
-TMP_HELMFILE="$(dirname ${HELMFILE})/.tmp_helmfile.$(mktemp -u XXXXXX).yaml"
+
+HELMFILE="${ROOT}/k8s/helmfile/only-for-argo-value-generation.yaml"
+TMP_HELMFILE="$(dirname "${HELMFILE}")/.tmp_helmfile.$(mktemp -u XXXXXX).yaml.gotmpl"
 
 if [[ -n "$3" ]]; then
     OUTPUT_TEMPLATE="$3"

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -23,6 +23,10 @@ profiles:
               image: local/skaffold/wbaas/ui
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "../bin/generate-values", "local", "ui" ]
 metadata:
   name: ui
 
@@ -98,6 +102,10 @@ profiles:
               image: local/skaffold/wbaas/api
             imageStrategy:
               helm: {}
+        hooks:
+          before:
+            - host:
+                command: [ "../bin/generate-values", "local", "api" ]
 metadata:
   name: api
 

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -92,7 +92,7 @@ profiles:
           - name: api
             chartPath: ./../../charts/charts/api
             valuesFiles:
-              - "../k8s/argocd/local/ui.values.yaml"
+              - "../k8s/argocd/local/api.values.yaml"
               - NeverPull.yaml
             artifactOverrides:
               image: local/skaffold/wbaas/api

--- a/skaffold/skaffold.yaml
+++ b/skaffold/skaffold.yaml
@@ -17,16 +17,12 @@ profiles:
           - name: ui
             chartPath: ./../../charts/charts/ui
             valuesFiles:
-              - ".tmp.values.ui.yaml"
+              - "../k8s/argocd/local/ui.values.yaml"
               - NeverPull.yaml
             artifactOverrides:
               image: local/skaffold/wbaas/ui
             imageStrategy:
               helm: {}
-        hooks:
-          before:
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "ui", "-n" ]
 metadata:
   name: ui
 
@@ -96,16 +92,12 @@ profiles:
           - name: api
             chartPath: ./../../charts/charts/api
             valuesFiles:
-              - ".tmp.values.api.yaml"
+              - "../k8s/argocd/local/ui.values.yaml"
               - NeverPull.yaml
             artifactOverrides:
               image: local/skaffold/wbaas/api
             imageStrategy:
               helm: {}
-        hooks:
-          before:
-            - host:
-                command: [ "./helmfile-values", "-e", "local", "-r", "api", "-n" ]
 metadata:
   name: api
 


### PR DESCRIPTION
This uses the existing values we generate and pass to Argo for skaffold rather than trying to generate them with the helmfile-values script in a `before` skaffold hook

Bug: T425581
