### PR TITLE
helmfile values: increase sql storage to 600GiB

### DIFF
--- a/k8s/helmfile/env/production/private.yaml
+++ b/k8s/helmfile/env/production/private.yaml
@@ -19,7 +19,7 @@ services:
           - /api(/|$)(.*)
   sql:
     storageClass: premium-rwo
-    storageSize: 480Gi
+    storageSize: 600Gi
     api:
       db: apidb
       user: apiuser


### PR DESCRIPTION
Increase SQL storage from 480 GiB to 600 GiB to stop the PV utilization exceeding the 70% threshold that triggers an alert [1]. This modifies the size of both the "primary" and "secondary" PVCs.

https://console.cloud.google.com/monitoring/alerting/alerts/0.o7qbvzcda43e?channelType=mail&project=wikibase-cloud

Bug: T425906

