### PR TITLE
Use ingress-nginx from the chainguard fork built by porter

### DIFF
--- a/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/ingress-nginx.values.yaml.gotmpl
@@ -2,6 +2,11 @@ controller:
   resources:
     limits:
       cpu: 100m
+  image:
+    registry: ghcr.io
+    image: porter-dev/ingress-nginx-controller
+    tag: v1.15.5
+    digest: null
 
   admissionWebhooks:
     enabled: false

--- a/k8s/helmfile/env/staging/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/ingress-nginx.values.yaml.gotmpl
@@ -1,1 +1,6 @@
-# staging matches production
+controller:
+  image:
+    registry: ghcr.io
+    image: porter-dev/ingress-nginx-controller
+    tag: v1.15.5
+    digest: null

--- a/k8s/helmfile/helmfile.yaml.gotmpl
+++ b/k8s/helmfile/helmfile.yaml.gotmpl
@@ -114,6 +114,15 @@ releases:
     # that can be used instead of YAML anchors. When upgrading helmfile, check
     # if we can use this feature here instead.
     <<: *default_release
+    set:
+    - name: controller.image.registry
+      value: ghcr.io
+    - name: controller.image.image
+      value: porter-dev/ingress-nginx-controller
+    - name: controller.image.tag
+      value: v1.15.5
+    - name: controller.image.digest
+      value: null
 
   - name: sql
     namespace: default

--- a/k8s/helmfile/helmfile.yaml.gotmpl
+++ b/k8s/helmfile/helmfile.yaml.gotmpl
@@ -114,15 +114,6 @@ releases:
     # that can be used instead of YAML anchors. When upgrading helmfile, check
     # if we can use this feature here instead.
     <<: *default_release
-    set:
-    - name: controller.image.registry
-      value: ghcr.io
-    - name: controller.image.image
-      value: porter-dev/ingress-nginx-controller
-    - name: controller.image.tag
-      value: v1.15.5
-    - name: controller.image.digest
-      value: null
 
   - name: sql
     namespace: default


### PR DESCRIPTION
[porter](https://github.com/porter-dev/ingress-nginx) are building free images of chainguard's fork of ingress-nginx that chainguard are keeping behind their paywall.  This is not a longterm solution but better than sticking on the old one.
