### PR TITLE
production(api): increase account creation rate limit

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -156,7 +156,7 @@ wbstack:
   monitoringEmail: wb-cloud-monitoring@wikimedia.de
   qsBatchMarkFailedAfter: 3
   qsBatchPendingTimeout: PT300S
-  signupThrottlingLimit: 20
+  signupThrottlingLimit: 100
   signupThrottlingRange: PT24H
   subdomainSuffix: .wbaas.dev
   summaryCreationRateRanges:

--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -150,7 +150,7 @@ wbstack:
   monitoringEmail: wb-cloud-monitoring@wikimedia.de
   qsBatchMarkFailedAfter: 3
   qsBatchPendingTimeout: PT300S
-  signupThrottlingLimit: 20
+  signupThrottlingLimit: 100
   signupThrottlingRange: PT24H
   subdomainSuffix: .wikibase.cloud
   summaryCreationRateRanges:

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -53,7 +53,7 @@ wbstack:
   qsBatchMarkFailedAfter: 3
   qsBatchPendingTimeout: 'PT300S'
   signupThrottlingRange: 'PT24H'
-  signupThrottlingLimit: 20
+  signupThrottlingLimit: 100
   summaryCreationRateRanges:
     - 'PT24H'
     - 'P30D'

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -14,6 +14,8 @@ ingress:
     secretName: wikibase-dev-tls
 
 wbstack:
+  signupThrottlingRange: 'PT24H'
+  signupThrottlingLimit: 20
   wikiDbProvisionVersion: mw1.43-wbs2
   wikiDbUseVersion: mw1.43-wbs2
   monitoringEmail: "wb-cloud-monitoring+staging@wikimedia.de"


### PR DESCRIPTION
Due to many people signing up at an in person event, we got reports of people unable to sign up for a new account.

Temporarily increasing `signupThrottlingLimit` from `20` to `100` while this event is ongoing.

Bug: T427504
