### PR TITLE
Revert "production(api): increase account creation rate limit (#2770)"

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -156,7 +156,7 @@ wbstack:
   monitoringEmail: wb-cloud-monitoring@wikimedia.de
   qsBatchMarkFailedAfter: 3
   qsBatchPendingTimeout: PT300S
-  signupThrottlingLimit: 100
+  signupThrottlingLimit: 20
   signupThrottlingRange: PT24H
   subdomainSuffix: .wbaas.dev
   summaryCreationRateRanges:

--- a/k8s/argocd/production/api.values.yaml
+++ b/k8s/argocd/production/api.values.yaml
@@ -150,7 +150,7 @@ wbstack:
   monitoringEmail: wb-cloud-monitoring@wikimedia.de
   qsBatchMarkFailedAfter: 3
   qsBatchPendingTimeout: PT300S
-  signupThrottlingLimit: 100
+  signupThrottlingLimit: 20
   signupThrottlingRange: PT24H
   subdomainSuffix: .wikibase.cloud
   summaryCreationRateRanges:

--- a/k8s/helmfile/env/production/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/api.values.yaml.gotmpl
@@ -53,7 +53,7 @@ wbstack:
   qsBatchMarkFailedAfter: 3
   qsBatchPendingTimeout: 'PT300S'
   signupThrottlingRange: 'PT24H'
-  signupThrottlingLimit: 100
+  signupThrottlingLimit: 20
   summaryCreationRateRanges:
     - 'PT24H'
     - 'P30D'

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -14,8 +14,6 @@ ingress:
     secretName: wikibase-dev-tls
 
 wbstack:
-  signupThrottlingRange: 'PT24H'
-  signupThrottlingLimit: 20
   wikiDbProvisionVersion: mw1.43-wbs2
   wikiDbUseVersion: mw1.43-wbs2
   monitoringEmail: "wb-cloud-monitoring+staging@wikimedia.de"


### PR DESCRIPTION
Revert the rate limit to 20 signups in a 24Hr period.

This reverts commit 208eb38 which was a temporary change to increase the account creation rate limit on production while an event was happening. 

Bug: T427504
