### PR TITLE
Enable required GitHub Actions to be manually triggered

### DIFF
--- a/.github/workflows/check-generated-values.yml
+++ b/.github/workflows/check-generated-values.yml
@@ -1,4 +1,4 @@
-on: [push, workflow_dispatch]
+on: [ push, workflow_dispatch ]
 name: Check values files
 jobs:
   diff:

--- a/.github/workflows/check-generated-values.yml
+++ b/.github/workflows/check-generated-values.yml
@@ -1,4 +1,4 @@
-on: push
+on: [push, workflow_dispatch]
 name: Check values files
 jobs:
   diff:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-on: push
+on: [push, workflow_dispatch]
 name: Lint
 jobs:
   lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,4 +1,4 @@
-on: [push, workflow_dispatch]
+on: [ push, workflow_dispatch ]
 name: Lint
 jobs:
   lint:


### PR DESCRIPTION
Make the required GitHub Actions listen on the `workflow_dispatch`[1] event to enable them to be triggered manually.

By default, third-party PRs don't trigger GitHub Actions for security reasons. Therefore, it will be useful to be able to manually trigger the GitHub Actions that are required to run before a PR can be merged.

[1]: https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_dispatch

Bug: T428767