### PR TITLE
Use ingress-nginx from the chainguard fork built by porter on production

### DIFF
--- a/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/ingress-nginx.values.yaml.gotmpl
@@ -9,6 +9,11 @@ controller:
       memory: 150Mi
     limits:
       cpu: null
+  image:
+    registry: ghcr.io
+    image: porter-dev/ingress-nginx-controller
+    tag: v1.15.5
+    digest: null
   config:
     http-snippet: >-
       geo $limit_from_cloud_provider {


### PR DESCRIPTION
follow-up #2765, for production

Bug: T428143
