### PR TITLE
Revert "Staging+Local: Deploy new Platform API image ghcr.io/wbstack/api:sha-fbc21c0"

### DIFF
--- a/k8s/argocd/local/api.values.yaml
+++ b/k8s/argocd/local/api.values.yaml
@@ -56,7 +56,7 @@ app:
     tracingEnabled: false
   url: https://www.wbaas.dev
 image:
-  tag: sha-fbc21c0
+  tag: sha-459d0f6
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/argocd/staging/api.values.yaml
+++ b/k8s/argocd/staging/api.values.yaml
@@ -55,7 +55,7 @@ app:
     tracingEnabled: false
   url: https://www.wikibase.dev
 image:
-  tag: sha-fbc21c0
+  tag: sha-459d0f6
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx

--- a/k8s/helmfile/env/local/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/local/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: sha-fbc21c0
+  tag: sha-459d0f6
 
 ingress:
   tls: null

--- a/k8s/helmfile/env/staging/api.values.yaml.gotmpl
+++ b/k8s/helmfile/env/staging/api.values.yaml.gotmpl
@@ -1,5 +1,5 @@
 image:
-  tag: sha-fbc21c0
+  tag: sha-459d0f6
 
 replicaCount:
   web: 1


### PR DESCRIPTION
bug found, therefore revert.

if active_from is null it gets filled with todays date

```
      App\Policy {#8325
        id: 3,
        policy_type: "terms-of-use",
        active_from: null,
        content_vue_file: "terms-of-use/version-2.vue",
        created_at: "2026-07-23 14:42:57",
        updated_at: "2026-07-23 14:42:57",
      },
```

```
 $ curl -Ls https://www.wikibase.dev/api/v1/policies/terms-of-use/upcoming | jq
{
  "metadata": {
    "policy_id": 3,
    "type": "terms-of-use",
    "active_from": "2026-07-24",
    "content_vue_file": "terms-of-use/version-2.vue"
  }
}
```

Reverts wmde/wbaas-deploy#2923
