### PR TITLE
production+staging(quickstatements): increase memory resource

### DIFF
--- a/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/tool-quickstatements.values.yaml.gotmpl
@@ -17,7 +17,7 @@ php:
 resources:
   requests:
     cpu: 1m
-    memory: 40Mi
+    memory: 120Mi
   limits:
     cpu: null
-    memory: 100Mi
+    memory: 300Mi


### PR DESCRIPTION
Increase (triple) request and limit of memory to try and prevent being killed by OOM.

This commit increases the resources in both environments since we don't adjust them in staging and considering the limited size of the resources it doesn't seem worth having the disparity vs increased consumption.

Bug: T434076
