### PR TITLE
prod: increase backup scratch disk size

### DIFF
--- a/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
+++ b/k8s/helmfile/env/production/wbaas-backup.values.yaml.gotmpl
@@ -6,7 +6,7 @@ image:
 job:
   cronSchedule: "0 20 * * *"
 
-scratchDiskSpace: 256Gi
+scratchDiskSpace: 512Gi
 
 storage:
   bucketName: wikibase-cloud-sql-backup


### PR DESCRIPTION
As the total size of the backups increase, the scratch disk space needs adjustment too from time to time.
Last time[1] we went from 128GB to 256GB.
In this PR I doubled it again to 512GB, which is maybe a bit much, but also not too dramatic for this temporary disk I think.

[1] https://github.com/wmde/wbaas-deploy/pull/2102

https://phabricator.wikimedia.org/T435042

Bug: T435042